### PR TITLE
Do not show keyboard when there is no input in the view - Closes #311

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
         android:name=".MainActivity"
          android:label="@string/app_name"
          android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-         android:windowSoftInputMode="stateVisible|adjustResize">
+         android:windowSoftInputMode="stateHidden|adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
# What was the bug or feature?
Described in #311 
This issue only happens in Android.

### How did I fix it?
The issue stems in `stateVisible` defined to `windowSoftInputMode`. as the [documents suggest](https://developer.android.com/guide/topics/manifest/activity-element):

> `stateHidden`: The soft keyboard is hidden when the user chooses the activity — that is when the user affirmatively navigates forward to the activity, rather than backs into it because of leaving another activity.


## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Open the app in android devices. It should not open the keyboard when there is no input in the view.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes