### PR TITLE
Use current theme in InfiniteScrollView component

### DIFF
--- a/src/components/infiniteScrollView/index.js
+++ b/src/components/infiniteScrollView/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScrollView, RefreshControl } from 'react-native';
+import { themes, colors } from '../../constants/styleGuide';
 
 /**
  * InfiniteScrollView is a wrapper for react native ScrollView
@@ -31,7 +32,7 @@ class InfiniteScrollView extends React.Component {
     this.canLoadMore = (this.props.list.length !== nextProps.list.length) || this.state.refreshing;
   }
 
-  onScroll(e) {
+  onScroll = (e) => {
     this.props.onScroll(e);
     this.loadMore(e);
   }
@@ -50,20 +51,29 @@ class InfiniteScrollView extends React.Component {
   }
 
   render() {
-    return <ScrollView onScroll={this.onScroll.bind(this)}
-      refreshControl={
-        <RefreshControl
-          refreshing={this.state.refreshing}
-          onRefresh={this.onRefresh}
+    return (
+      <ScrollView
+        onScroll={this.onScroll}
+        refreshControl={
+          <RefreshControl
+            onRefresh={this.onRefresh}
+            refreshing={this.state.refreshing}
+            tintColor={this.props.theme === themes.light ? colors.light.gray4 : colors.dark.gray4}
           />
-      }
-      ref={((el) => { this.scrollView = el; })}
-      style={this.props.style}
-      stickyHeaderIndices={this.props.stickyHeaderIndices}
-      scrollEventThrottle={8}>
-      {this.props.children}
-    </ScrollView>;
+        }
+        ref={((el) => { this.scrollView = el; })}
+        style={this.props.style}
+        stickyHeaderIndices={this.props.stickyHeaderIndices}
+        scrollEventThrottle={8}
+      >
+        {this.props.children}
+      </ScrollView>
+    );
   }
 }
+
+InfiniteScrollView.defaultProps = {
+  theme: themes.light,
+};
 
 export default InfiniteScrollView;

--- a/src/components/ownWallet/index.js
+++ b/src/components/ownWallet/index.js
@@ -127,6 +127,7 @@ class Wallet extends React.Component {
           scrollEventThrottle={8}
           onScroll={this.onScroll.call(this)}
           style={[styles.scrollView]}
+          theme={this.props.theme}
           list={[...transactions.pending, ...transactions.confirmed]}
           count={transactions.count}
           refresh={this.props.updateTransactions}


### PR DESCRIPTION
# What was the bug or feature?
Described in #383 

### How did I fix it?
Passed current theme as a prop to InfiniteScrollView component and changed tint color of RefreshControl component with respect to the theme.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Open app in iOS, pull transaction list to trigger a refresh.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
