### PR TITLE
Reset the BioAuth method after signing out - Closes #392

### DIFF
--- a/src/components/signOutButton/index.js
+++ b/src/components/signOutButton/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavigationActions } from 'react-navigation';
+import { removePassphraseFromKeyChain } from '../../utilities/passphrase';
 import { IconButton } from '../toolBox/button';
 import { colors } from '../../constants/styleGuide';
 import withTheme from '../withTheme';
@@ -9,6 +10,7 @@ class SignOutButton extends React.Component {
   onClick = () => {
     // clean active account
     this.props.signOut();
+    removePassphraseFromKeyChain();
 
     // navigate to the signIn page
     this.props.navigation


### PR DESCRIPTION
# What was the bug or feature?
Described in #392 

### How did I fix it?
Used `removePassphraseFromKeyChain` from the `passphrase` utility to remove the stored passphrase from the keyChain after the user pressed sign out.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
 - The user must be able to sign in using the bioAuth method if closed and opened the app.
 - The user must land onto the sign in form screen after signing out.
 - Closing and opening the app should not change the state of the bioAuth method usage.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes