### PR TITLE
Use returnKeyType prop on Input component - Closes #71

### DIFF
--- a/src/components/signIn/form.js
+++ b/src/components/signIn/form.js
@@ -129,6 +129,8 @@ class Form extends React.Component {
             multiline={Platform.OS === 'ios'}
             secureTextEntry={Platform.OS !== 'ios'}
             error={errorMessage}
+            returnKeyType={Platform.OS === 'android' ? 'send' : 'default'}
+            onSubmitEditing={Platform.OS === 'android' ? this.onSignInSubmission : null}
           />
         </Animated.View>
         <KeyboardAwareScrollView

--- a/src/components/toolBox/input/index.js
+++ b/src/components/toolBox/input/index.js
@@ -13,10 +13,10 @@ import getStyles from './styles';
  * @param {Number} props.size - THe size of the icon in pixels, defaults to 35
  */
 const Input = ({
-  reference = () => {}, innerStyles = {},
-  label, styles, value, onChange, error,
-  multiline, onFocus, autoFocus, onBlur, autoCorrect,
-  keyboardType, secureTextEntry,
+  reference = () => {}, innerStyles = {}, styles = {},
+  label, value, error, multiline, autoFocus, autoCorrect, secureTextEntry,
+  keyboardType = 'default', returnKeyType = 'default',
+  onChange, onFocus, onBlur, onSubmitEditing,
 }) => {
   const inputStyle = [
     styles.input,
@@ -38,7 +38,7 @@ const Input = ({
         multiline={multiline}
         ref={input => reference(input)}
         value={value}
-        keyboardType={keyboardType || 'default'}
+        keyboardType={keyboardType}
         autoFocus={autoFocus}
         onChangeText={onChange}
         autoCorrect={autoCorrect}
@@ -46,6 +46,8 @@ const Input = ({
         allowFontScaling={false}
         secureTextEntry={secureTextEntry}
         onBlur={onBlur}
+        returnKeyType={returnKeyType}
+        onSubmitEditing={onSubmitEditing}
       />
 
       {error ? (


### PR DESCRIPTION
# What was the bug or feature?
Described in #71 

### How did I fix it?
- Updated `toolBox/Input` component to use and pass the `returnKeyType` prop to `TextInput`
- Updated Sign In Form to use `send` returnKeyType on Android (we can't do that in iOS because of multiline input)
- @reyraa I am not sure if we should implement this to current Send form since it's going to change.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Open app in Android, try to sign in by pressing the action key on the keyboard.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
