### PR TITLE
Refactor Register screen's navigation listeners - Closes #402

### DIFF
--- a/src/components/register/index.js
+++ b/src/components/register/index.js
@@ -13,53 +13,60 @@ import { colors } from '../../constants/styleGuide';
 const NavButton = props =>
   <Text {...props} style={[styles.navButton, props.disabled ? styles.disabledNavButton : null]} />;
 const ActiveTitle = props => <Small style={styles.activeGroupTitle} {...props} />;
-let backCallback;
 class Register extends React.Component {
-  state = {
-    showNav: true,
-  };
   static navigationOptions = ({ navigation }) => {
     const { params = {} } = navigation.state;
-    backCallback = () => {
-      params.action();
-      return true;
-    };
-    BackHandler.addEventListener('hardwareBackPress', backCallback);
     return {
       headerStyle: {
         backgroundColor: '#F9FDFF',
-        borderBottomWidth: 0,
         elevation: 0,
       },
       headerTitleStyle: {
         textAlign: 'center',
         flex: 1,
       },
-      headerLeft: (params && params.action) ? <IconButton
-        icon='back'
-        title=''
-        onPress={() => {
-          params.action();
-        }}
-        style={styles.backButton}
-        color={colors.light.gray1}/> :
-        null,
-      headerRight: (params && params.action) ? <IconButton color='transparent' icon='back'/> : null,
+      headerLeft: (
+        <IconButton
+          icon='back'
+          title=''
+          onPress={() => (params.action ? params.action() : navigation.pop())}
+          style={styles.backButton}
+          color={colors.light.gray1}
+        />
+      ),
+      headerRight: <IconButton color='transparent' icon='back'/>,
     };
   };
+
+  state = {
+    showNav: true,
+  };
+
+  componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPressedAndroid);
+  }
+
+  componentWillUnmount() {
+    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPressedAndroid);
+  }
+
+  onBackButtonPressedAndroid = () => {
+    const action = this.props.navigation.getParam('action', false);
+
+    if (action && typeof action === 'function') {
+      action();
+      return true;
+    }
+
+    return false;
+  }
+
   hideNav = () => {
     this.setState({
       showNav: false,
     });
   }
-  componentDidMount() {
-    this.props.navigation.addListener('willBlur', () => {
-      BackHandler.addEventListener('hardwareBackPress', () => {
-        this.props.navigation.pop();
-        return true;
-      });
-    });
-  }
+
   render() {
     const { navigation } = this.props;
     const noNavStyle = this.state.showNav ? {} : { paddingBottom: 0 };

--- a/src/components/register/index.js
+++ b/src/components/register/index.js
@@ -19,6 +19,7 @@ class Register extends React.Component {
     return {
       headerStyle: {
         backgroundColor: '#F9FDFF',
+        borderBottomWidth: 0,
         elevation: 0,
       },
       headerTitleStyle: {

--- a/src/components/register/intro/index.js
+++ b/src/components/register/intro/index.js
@@ -15,11 +15,8 @@ class Intro extends React.Component {
   }
 
   componentDidMount() {
-    const passphrase = generatePassphrase();
-    this.setState({
-      passphrase,
-    });
-    this.props.navigation.setParams({ action: this.props.navigation.pop });
+    this.setState({ passphrase: generatePassphrase() });
+    this.props.navigation.setParams({ action: false });
   }
 
   confirm = (status) => {
@@ -84,12 +81,13 @@ class Intro extends React.Component {
                 I understand that it is my responsibility to keep my passphrase safe.
               </Small>
             </View>
-          <SecondaryButton
-            disabled={this.state.buttonStatus}
-            noTheme={true}
-            style={styles.button}
-            onClick={this.forward}
-            title='Continue' />
+            <SecondaryButton
+              disabled={this.state.buttonStatus}
+              noTheme={true}
+              style={styles.button}
+              onClick={this.forward}
+              title='Continue'
+            />
           </View>
         </View>
       </ScrollView>);

--- a/src/components/register/success/index.js
+++ b/src/components/register/success/index.js
@@ -10,6 +10,7 @@ class Success extends React.Component {
     this.props.hideNav();
     this.props.navigation.setParams({ action: false });
   }
+
   render() {
     return (
       <View style={styles.container}>
@@ -32,10 +33,12 @@ class Success extends React.Component {
         <View>
           <SecondaryButton
             style={styles.button}
-            onClick={() => this.props.navigation.navigate('SignIn', { signOut: true })}
-            title='Sign in now' />
+            onClick={this.props.navigation.pop}
+            title='Sign in now'
+          />
         </View>
-      </View>);
+      </View>
+    );
   }
 }
 

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Platform } from 'react-native';
+import { ScrollView, View, Platform } from 'react-native';
 import connect from 'redux-connect-decorator';
 import { accountSignedOut as accountSignedOutAction } from '../../actions/accounts';
 import { H1, H4, P } from '../toolBox/typography';
@@ -68,7 +68,7 @@ class Settings extends React.Component {
     </P>;
 
     return (
-      <View style={[styles.container, styles.theme.container]}>
+      <ScrollView style={[styles.container, styles.theme.container]}>
         <H1 style={styles.theme.header}>Settings</H1>
         <View style={styles.group}>
           <H4 style={styles.theme.subHeader}>Security</H4>
@@ -170,7 +170,7 @@ class Settings extends React.Component {
           Platform.OS === 'android' ?
           <FingerprintOverlay error={this.state.error} show={this.state.show} /> : null
         }
-      </View>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
# What was the bug or feature?
#402 

### How did I fix it?
Updated navigation listeners of Register page as suggested in [react-navigation's docs](https://reactnavigation.org/docs/en/1.x/custom-android-back-button-handling.html#docsNav)

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
