### PR TITLE
Add warning before sign out - Closes #424

### DIFF
--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -5,7 +5,7 @@ import { accountSignedOut as accountSignedOutAction } from '../../actions/accoun
 import { H1, H4, P } from '../toolBox/typography';
 import FingerprintOverlay from '../fingerprintOverlay';
 import ItemTitle from './itemTitle';
-import SignOutButton from '../signOutButton';
+import SignOutButton from './signOutButton';
 import { colors, themes } from '../../constants/styleGuide';
 import withTheme from '../withTheme';
 import SwitchButton from './switchButton';

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -170,7 +170,11 @@ class Settings extends React.Component {
           <View style={[styles.group, styles.signOut]}>
             <H4 style={[styles.subHeader, styles.theme.subHeader]}>{''}</H4>
             <View style={[styles.item, styles.theme.item]}>
-              <SignOutButton navigation={navigation} signOut={this.props.accountSignedOut} />
+              <SignOutButton
+                navigation={navigation}
+                signOut={this.props.accountSignedOut}
+                settings={settings}
+              />
             </View>
           </View>
         </ScrollView>

--- a/src/components/settings/signOutButton/index.js
+++ b/src/components/settings/signOutButton/index.js
@@ -31,7 +31,7 @@ class SignOutButton extends React.Component {
     let message;
 
     if (settings.hasStoredPassphrase) {
-      message = `You will need to reconfigure ${settings.sensorType} after signing in.`;
+      message = `You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`;
     }
 
     Alert.alert('Are you sure?', message, [

--- a/src/components/settings/signOutButton/index.js
+++ b/src/components/settings/signOutButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import { NavigationActions } from 'react-navigation';
 import { removePassphraseFromKeyChain } from '../../../utilities/passphrase';
 import { IconButton } from '../../toolBox/button';
@@ -7,7 +8,7 @@ import withTheme from '../../withTheme';
 import getStyles from './styles';
 
 class SignOutButton extends React.Component {
-  onClick = () => {
+  onConfirm = () => {
     // clean active account
     this.props.signOut();
     removePassphraseFromKeyChain();
@@ -23,6 +24,26 @@ class SignOutButton extends React.Component {
           },
         })],
       }));
+  }
+
+  onClick = () => {
+    const { settings } = this.props;
+    let message;
+
+    if (settings.hasStoredPassphrase) {
+      message = `You will need to reconfigure ${settings.sensorType} after signing in.`;
+    }
+
+    Alert.alert('Are you sure?', message, [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Confirm',
+        onPress: this.onConfirm,
+      },
+    ], { cancelable: false });
   }
 
   render() {

--- a/src/components/settings/signOutButton/index.js
+++ b/src/components/settings/signOutButton/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { NavigationActions } from 'react-navigation';
-import { removePassphraseFromKeyChain } from '../../utilities/passphrase';
-import { IconButton } from '../toolBox/button';
-import { colors } from '../../constants/styleGuide';
-import withTheme from '../withTheme';
+import { removePassphraseFromKeyChain } from '../../../utilities/passphrase';
+import { IconButton } from '../../toolBox/button';
+import { colors } from '../../../constants/styleGuide';
+import withTheme from '../../withTheme';
 import getStyles from './styles';
 
 class SignOutButton extends React.Component {

--- a/src/components/settings/signOutButton/styles.js
+++ b/src/components/settings/signOutButton/styles.js
@@ -1,4 +1,4 @@
-import { themes, colors } from '../../constants/styleGuide';
+import { themes, colors } from '../../../constants/styleGuide';
 
 export default () => ({
   common: {


### PR DESCRIPTION
# What was the bug or feature?
#424 

### How did I fix it?
- Moved signout button to settings folder, since it's only used there.
- Updated signout button click handler.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Login, go to settings page then try to sign out.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
