### PR TITLE
Show less floating digits when the number is big - Closes #416

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9160,11 +9160,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
-    "numeral": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
-    },
     "nwsapi": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
@@ -9984,7 +9979,7 @@
       }
     },
     "react-native-app-settings": {
-      "version": "github:KrazyLabs/react-native-app-settings#9a91f2a2504908433635b16b1ffdcdc720d246fc"
+      "version": "github:KrazyLabs/react-native-app-settings#909d19e1f49bd6626d32b619f8926187b84474ec"
     },
     "react-native-background-timer": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@liskhq/lisk-client": "2.0.0",
     "lottie-react-native": "=2.5.9",
     "moment": "^2.22.0",
-    "numeral": "^2.0.6",
     "path-browserify": "0.0.0",
     "process": "^0.11.10",
     "prop-types": "^15.6.0",

--- a/src/components/formattedNumber/index.js
+++ b/src/components/formattedNumber/index.js
@@ -1,13 +1,18 @@
 import React from 'react';
-import numeral from 'numeral';
+import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
 
+const reg2 = /-?([1-9]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
+
 const FormattedNumber = ({
-  val, children, type, style,
+  val, children, type, style, trim,
 }) => {
   const Element = type || Text;
-  const formatedNumber = numeral(val || children).format('0,0.[0000000000000]');
-  return <Element style={style}>{formatedNumber} LSK</Element>;
+  const bigNum = new BigNumber(val || children);
+  const formatedNumber = bigNum.toFormat();
+  const matched = formatedNumber.match(reg2);
+  const normalizedVal = trim && matched ? matched[0].replace(/\.$/, '') : formatedNumber;
+  return <Element style={style}>{normalizedVal} LSK</Element>;
 };
 
 export default FormattedNumber;

--- a/src/components/transactions/item.js
+++ b/src/components/transactions/item.js
@@ -86,7 +86,7 @@ class Item extends React.Component {
               styles.amount,
               styles[direction], styles.theme[direction],
             ]}>
-              <FormattedNumber>{amount}</FormattedNumber>
+              <FormattedNumber trim={true}>{amount}</FormattedNumber>
             </B> : null
         }
         {


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #416 
Also fixed the issue causing NaN when the value is `*.00000001`.

### How did I fix it?
Used Big Number package to format the value and also removed the less important digits using regex.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)


### How to test it?
 - It shouldn't show NaN.
 - It shouldn't show more than 3 floating digits if the value is bigger than 1.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
