### PR TITLE
Fix the alignment of Address and bookmark label on Ready to Send step - Closes #496

### DIFF
--- a/src/components/send/overview/index.js
+++ b/src/components/send/overview/index.js
@@ -114,7 +114,7 @@ class Overview extends React.Component {
       styles, accounts: { followed }, sharedData: { address, amount, reference },
     } = this.props;
 
-    const bookmark = followed.filter(item => item.address === address);
+    const bookmark = followed.find(item => item.address === address);
     const fee = actionType === 'initialize' ? 0 : 1e7;
 
     return (
@@ -133,15 +133,16 @@ class Overview extends React.Component {
           <View style={[styles.row, styles.theme.row, styles.addressContainer]}>
             <Avatar address={address || ''} style={styles.avatar} size={50}/>
             {
-              bookmark.length === 1 ?
-                <H4 style={styles.theme.text}>{bookmark[0].label}</H4> : null
+              bookmark ? <H4 style={styles.theme.text}>{bookmark.label}</H4> : null
             }
             <P style={[styles.address, styles.text, styles.theme.text]}>{address}</P>
           </View>
           <View style={[styles.row, styles.theme.row]}>
-            <Icon name={actionType === 'initialize' ? 'tx-fee' : 'amount'}
+            <Icon
+              name={actionType === 'initialize' ? 'tx-fee' : 'amount'}
               style={styles.icon} size={20}
-              color={colors[this.props.theme].gray2} />
+              color={colors[this.props.theme].gray2}
+            />
             <View style={styles.rowContent}>
               <P style={[styles.label, styles.theme.label]}>
                 {actionType === 'initialize' ? 'Transaction Fee' : 'Amount (including 0.1 LSK)'}

--- a/src/components/send/overview/styles.js
+++ b/src/components/send/overview/styles.js
@@ -49,7 +49,6 @@ export default () => ({
     text: {
       flexWrap: 'wrap',
       flex: 1,
-      paddingRight: 20,
     },
     subtitle: {
       marginTop: 7,


### PR DESCRIPTION
# What was the bug or feature?
#496 

### How did I fix it?
Removed padding right from text styling on Ready to Send step 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
