### PR TITLE
Fix reference value overflow on TxDetails Screen - Closes #495

### DIFF
--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -190,7 +190,9 @@ class TransactionDetail extends React.Component {
               />
               <View style={styles.rowContent}>
                 <P style={[styles.label, styles.theme.label]}>Reference</P>
-                <B style={[styles.value, styles.theme.value]}>{tx.asset.data}</B>
+                <B style={[styles.value, styles.theme.value, styles.referenceValue]}>
+                  {tx.asset.data}
+                </B>
               </View>
             </View> : null
         }

--- a/src/components/txDetail/styles.js
+++ b/src/components/txDetail/styles.js
@@ -25,6 +25,10 @@ export default () => ({
       fontFamily: fonts.family.context,
       fontWeight: 'bold',
     },
+    referenceValue: {
+      flexWrap: 'wrap',
+      paddingRight: 30,
+    },
     label: {
       fontSize: 13,
       marginBottom: 7,


### PR DESCRIPTION
# What was the bug or feature?
#495 

### How did I fix it?
Added extra padding right to reference value

## Type of change
- Bug fix (a non-breaking change which fixes an issue)


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
