### PR TITLE
Fix the regex in FormattedNumber - Closes #511

### DIFF
--- a/src/components/formattedNumber/index.js
+++ b/src/components/formattedNumber/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
 
-const reg2 = /-?([1-9]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
+const reg2 = /-?([1-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
 
 const FormattedNumber = ({
   val, children, type, style, trim,


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #511 

### How did I fix it?
Since the issue stems in the comma thousand separators, simply adding it to the expected group fixes the issue.

```
/-?([1-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g
```

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Transaction amounts over 1K must be properly trimmed in transactions list and fully visible in the transaction details page.
