### PR TITLE
Update keyboard appearance with respect to the theme (iOS) - Closes #470 

### DIFF
--- a/src/components/signIn/form.js
+++ b/src/components/signIn/form.js
@@ -160,6 +160,7 @@ class Form extends React.Component {
             multiline={Platform.OS === 'ios'}
             secureTextEntry={Platform.OS !== 'ios'}
             error={errorMessage}
+            keyboardAppearance="light"
           />
           {
             passphrase.value === '' ?

--- a/src/components/toolBox/input/index.js
+++ b/src/components/toolBox/input/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput } from 'react-native';
+import { themes } from '../../../constants/styleGuide';
 import Icon from '../icon';
 import withTheme from '../../withTheme';
 import getStyles from './styles';
@@ -14,9 +15,9 @@ import getStyles from './styles';
  */
 const Input = ({
   reference = () => {}, innerStyles = {},
-  label, styles, value, onChange, error,
+  label, styles, theme, value, onChange, error,
   multiline, onFocus, autoFocus, onBlur, autoCorrect,
-  keyboardType, secureTextEntry,
+  keyboardType = 'default', secureTextEntry, keyboardAppearance,
 }) => {
   const inputStyle = [
     styles.input,
@@ -25,6 +26,10 @@ const Input = ({
     (error ? styles.inputErrorStyle : {}),
     (error ? styles.theme.inputErrorStyle : {}),
   ];
+
+  if (!keyboardAppearance) {
+    keyboardAppearance = theme === themes.dark ? 'dark' : 'light';
+  }
 
   return (
     <View style={[styles.inputContainer, innerStyles.containerStyle]}>
@@ -38,7 +43,8 @@ const Input = ({
         multiline={multiline}
         ref={input => reference(input)}
         value={value}
-        keyboardType={keyboardType || 'default'}
+        keyboardType={keyboardType}
+        keyboardAppearance={keyboardAppearance}
         autoFocus={autoFocus}
         onChangeText={onChange}
         autoCorrect={autoCorrect}


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #470 

### How did I fix it?
- Added `keyboardAppearance` prop to `toolBox/Input` component
- Updated `keyboardAppearance` with respect to the theme if not passed from the props
- Forced SignIn screen's keyboard to be light

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Switch between dark and light modes to see keyboard appearance on iOS

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
