### PR TITLE
Add data retrieval to transaction details page - Closes #477

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -178,7 +178,7 @@ class Home extends React.Component {
     let content = null;
 
     if (!transactions.loaded) {
-      content = <Loading />;
+      content = <Loading style={styles.loadingState} />;
     } else {
       const listElements = transactions.count > 0 ?
         [...transactions.pending, ...transactions.confirmed] :

--- a/src/components/home/styles.js
+++ b/src/components/home/styles.js
@@ -17,6 +17,9 @@ export default () => ({
       top: 0,
       width: '100%',
     },
+    loadingState: {
+      marginTop: 170,
+    },
   },
   [themes.light]: {
     container: {

--- a/src/components/transactions/loading.js
+++ b/src/components/transactions/loading.js
@@ -12,6 +12,7 @@ const LoadingState = ({ theme, styles, style = {} }) => (
       <Image source={noActivityLight} style={styles.loading} /> :
       <Image source={noActivityDark} style={styles.loading} />
     }
-  </View>);
+  </View>
+);
 
 export default withTheme(LoadingState, getStyles());

--- a/src/components/transactions/styles.js
+++ b/src/components/transactions/styles.js
@@ -61,7 +61,6 @@ export default () => ({
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',
-      marginTop: 170,
     },
     emptyStateActivityIndicator: {
       position: 'absolute',

--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { ScrollView, View, Image, ActivityIndicator } from 'react-native';
+import { ScrollView, View, Image } from 'react-native';
 import connect from 'redux-connect-decorator';
 import FormattedDate from '../formattedDate';
 import withTheme from '../withTheme';
@@ -9,6 +9,7 @@ import Share from '../share';
 import { B, P, H1, H3, A } from '../toolBox/typography';
 import Icon from '../toolBox/icon';
 import Avatar from '../avatar';
+import Loading from '../transactions/loading';
 import transactions from '../../constants/transactions';
 import { getTransactions } from '../../utilities/api/transactions';
 import Blur from '../transactions/blur';
@@ -67,9 +68,9 @@ class TransactionDetail extends React.Component {
 
     if (!tx) {
       return (
-        <ScrollView style={[styles.container, styles.containerLoading, styles.theme.container]}>
-          <ActivityIndicator size="large" />
-        </ScrollView>
+        <View style={[styles.container, styles.theme.container]}>
+          <Loading />
+        </View>
       );
     }
 

--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -28,7 +28,7 @@ const txTypes = ['accountInitialization', 'setSecondPassphrase', 'registerDelega
 class TransactionDetail extends React.Component {
   state = {
     tx: null,
-    loading: false,
+    refreshing: false,
   }
 
   componentDidMount() {
@@ -36,24 +36,28 @@ class TransactionDetail extends React.Component {
     const tx = navigation.getParam('tx', null);
 
     if (tx) {
-      this.setState({ tx });
+      this.setState({ tx }, () => this.retrieveTransaction(tx.id));
     } else {
       this.retrieveTransaction(navigation.getParam('txId', false));
     }
   }
 
   async retrieveTransaction(id, delay = 0) {
-    this.setState({ loading: true });
     try {
       const { data } = await getTransactions(this.props.activePeer, { id });
-      setTimeout(() => this.setState({ tx: data[0], loading: false }), delay);
+      setTimeout(() => this.setState({
+        tx: data[0],
+        refreshing: false,
+      }), delay);
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }
   }
 
   onRefresh = () => {
-    this.retrieveTransaction(this.state.tx.id, 1500);
+    this.setState({
+      refreshing: true,
+    }, () => this.retrieveTransaction(this.state.tx.id, 1500));
   }
 
   navigate = (address) => {
@@ -73,7 +77,7 @@ class TransactionDetail extends React.Component {
 
   render() {
     const { navigation, styles, theme } = this.props;
-    const { tx, loading } = this.state;
+    const { tx, refreshing } = this.state;
 
     if (!tx) {
       return (
@@ -108,7 +112,7 @@ class TransactionDetail extends React.Component {
         style={[styles.container, styles.theme.container]}
         refreshControl={(
           <RefreshControl
-            refreshing={loading}
+            refreshing={refreshing}
             onRefresh={this.onRefresh}
           />
         )}

--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -17,6 +17,7 @@ import arrowLight from '../../assets/images/txDetail/arrow-light2x.png';
 import arrowDark from '../../assets/images/txDetail/arrow-dark2x.png';
 import getStyles from './styles';
 import { colors, themes } from '../../constants/styleGuide';
+import { merge } from '../../utilities/helpers';
 
 const txTypes = ['accountInitialization', 'setSecondPassphrase', 'registerDelegate', 'vote'];
 
@@ -45,10 +46,11 @@ class TransactionDetail extends React.Component {
   async retrieveTransaction(id, delay = 0) {
     try {
       const { data } = await getTransactions(this.props.activePeer, { id });
-      setTimeout(() => this.setState({
-        tx: data[0],
+      const tx = data[0] || {};
+      setTimeout(() => this.setState(prevState => ({
+        tx: merge(prevState.tx, tx),
         refreshing: false,
-      }), delay);
+      })), delay);
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }

--- a/src/components/txDetail/styles.js
+++ b/src/components/txDetail/styles.js
@@ -7,6 +7,9 @@ export default () => ({
       paddingTop: 0,
       paddingBottom: 20,
     },
+    containerLoading: {
+      paddingTop: 20,
+    },
     divider: {
       margin: 20,
       marginBottom: 0,

--- a/src/components/txDetail/styles.js
+++ b/src/components/txDetail/styles.js
@@ -7,9 +7,6 @@ export default () => ({
       paddingTop: 0,
       paddingBottom: 20,
     },
-    containerLoading: {
-      paddingTop: 20,
-    },
     divider: {
       margin: 20,
       marginBottom: 0,

--- a/src/components/wallet/index.js
+++ b/src/components/wallet/index.js
@@ -198,7 +198,7 @@ class Wallet extends React.Component {
     let content = null;
 
     if (!transactions.loaded) {
-      content = <Loading style={styles.loadingState} />;
+      content = <Loading />;
     } else {
       const listElements = transactions.count > 0 ?
         [...transactions.pending, ...transactions.confirmed] :

--- a/src/components/wallet/styles.js
+++ b/src/components/wallet/styles.js
@@ -17,9 +17,6 @@ export default () => ({
       top: 0,
       width: '100%',
     },
-    loadingState: {
-      marginTop: 0,
-    },
   },
   [themes.light]: {
     container: {

--- a/src/utilities/api/transactions.js
+++ b/src/utilities/api/transactions.js
@@ -4,6 +4,7 @@ import Lisk from '@liskhq/lisk-client';
  * Gets the list of transactions for a given filtering config
  *
  * @param {Object} data
+ * @param {String?} data.id - A valid ID for specific transaction
  * @param {String?} data.senderId - A valid Lisk ID to filter the senderID
  * @param {String?} data.recipientId - A valid Lisk ID to filter the recipientId
  * @param {Number?} limit - defaults on 25


### PR DESCRIPTION
# What was the bug or feature?
Described in #477

### How did I fix it?
- Added `retrieveTransactions` method to TxDetail component, in case it does not have any tx passed from the navigation params.
- In order to make this flow work, we need to pass `txId` parameter.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- There are no user-facing changes on this branch but it'll be testable when we implement deep linking for transactions.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
