### PR TITLE
Implement deep linking api to iMessage bridge - Closes #557

### DIFF
--- a/ios/LiskMessageExtension/MessagesManager.m
+++ b/ios/LiskMessageExtension/MessagesManager.m
@@ -28,4 +28,10 @@ RCT_EXTERN_METHOD(updatePresentationStyle:
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 
+RCT_EXTERN_METHOD(openURL:
+                  (NSString *)urlString
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+
 @end

--- a/ios/LiskMessageExtension/MessagesManager.swift
+++ b/ios/LiskMessageExtension/MessagesManager.swift
@@ -75,7 +75,7 @@ class MessagesManager: RCTEventEmitter {
 
   @objc func composeMessage(_ messageData: [String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
     guard let conversation = self.messagesVC.activeConversation else {
-      fatalError("There's no conversation")
+      return reject("ERROR", "There's no conversation", nil)
     }
 
     let session = conversation.selectedMessage?.session ?? MSSession()
@@ -87,10 +87,24 @@ class MessagesManager: RCTEventEmitter {
 
     conversation.insert(message) { (error) in
       if error != nil {
-        return reject("ERROR", "ERROR", error)
+        return reject("ERROR", "Unable to insert message", error)
       }
 
       return resolve(Mappers.messageToObject(message: message, withParticipiantIdentifier: false))
     }
+  }
+
+  @objc func openURL(_ urlString: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    guard let url = URL(string: urlString) else {
+      return reject("ERROR", "Unable to construct url", nil)
+    }
+
+    self.messagesVC.extensionContext?.open(url, completionHandler: { (success) in
+      guard success == true else {
+        return reject("ERROR", "Unable to navigate to url", nil)
+      }
+
+      return resolve(url)
+    })
   }
 }

--- a/ios/LiskMessageExtension/README.md
+++ b/ios/LiskMessageExtension/README.md
@@ -28,6 +28,9 @@ This method can be used to update the presentation style. Returns updated style 
 ### composeMessage(message: MessageData) -> Promise
 Can be used to compose and insert a message object to the conversation. Returns a promise instance.
 
+### openURL(url: String) -> Promise
+Can be used to open a URL. Recommended for opening the host app. Returns a promise instance.
+
 ## Events
 ### didSelectMessage --> { conversation: Conversation, message: Message }
 Will be called when the user selects a message.

--- a/src/components/imessageForm/devSettings/index.js
+++ b/src/components/imessageForm/devSettings/index.js
@@ -21,6 +21,12 @@ class DevSettings extends React.Component {
     });
   }
 
+  onOpenDeepLink = () => {
+    NativeModules.MessagesManager.openURL('lisk://wallet')
+      .then(console.log)
+      .catch(console.log);
+  }
+
   render() {
     const { liveReloadEnabled } = this.state;
 
@@ -29,6 +35,12 @@ class DevSettings extends React.Component {
         <TouchableHighlight style={styles.button} onPress={this.onToggleLiveReload}>
           <Text style={styles.buttonText}>
             {liveReloadEnabled ? 'Disable' : 'Enable'} Live Reload
+          </Text>
+        </TouchableHighlight>
+
+        <TouchableHighlight style={styles.button} onPress={this.onOpenDeepLink}>
+          <Text style={styles.buttonText}>
+            Open Lisk App
           </Text>
         </TouchableHighlight>
       </View>

--- a/src/components/imessageForm/devSettings/styles.js
+++ b/src/components/imessageForm/devSettings/styles.js
@@ -9,6 +9,7 @@ export default StyleSheet.create({
     justifyContent: 'center',
     width: '100%',
     padding: 2,
+    flexDirection: 'row',
   },
   button: {
     alignItems: 'center',


### PR DESCRIPTION
# What was the bug or feature?
Described in #557 

### How did I fix it?
- Updated MessagesManager to contain and expose a method for opening deep links by using the [extensionContext](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621411-extensioncontext)
- Updated iMessage extension documentation
- Added an example to to iMessage app dev menu

## Type of change
- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

### How to test it?
Open the iMessage app in development mode, click `Open Lisk App` button.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
