### PR TITLE
Implement deep linking to transaction details - Closes #561

### DIFF
--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -139,7 +139,6 @@ const MainStack = StackNavigator(
         title: 'Transaction Details',
         headerTitle: HeaderTitle,
         headerRight: HeaderPlaceholderButton,
-        headerLeft: HeaderBackButton,
         headerBackground: <HeaderBackground />,
         headerStyle: {
           backgroundColor: 'transparent',

--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -8,6 +8,7 @@ import FormattedNumber from '../formattedNumber';
 import Share from '../share';
 import { B, P, H1, H3, A } from '../toolBox/typography';
 import Icon from '../toolBox/icon';
+import { IconButton } from '../toolBox/button';
 import Avatar from '../avatar';
 import Loading from '../transactions/loading';
 import transactions from '../../constants/transactions';
@@ -27,30 +28,62 @@ const txTypes = ['accountInitialization', 'setSecondPassphrase', 'registerDelega
   account: state.accounts.active || {},
 }), {})
 class TransactionDetail extends React.Component {
+  static navigationOptions = ({ navigation }) => {
+    const { params = {} } = navigation.state;
+
+    return {
+      headerLeft: (
+        <IconButton
+          title=''
+          icon='back'
+          onPress={params.action}
+          color={params.theme === themes.light ? colors.light.black : colors.dark.white}
+        />
+      ),
+    };
+  };
+
   state = {
     tx: null,
     refreshing: false,
   }
 
   componentDidMount() {
-    const { navigation } = this.props;
+    const { theme, navigation } = this.props;
     const tx = navigation.getParam('tx', null);
+    let backAction = () => navigation.pop();
 
     if (tx) {
       this.setState({ tx }, () => this.retrieveTransaction(tx.id));
     } else {
       this.retrieveTransaction(navigation.getParam('txId', false));
+      backAction = () => navigation.navigate('Home');
     }
+
+    navigation.setParams({
+      theme,
+      action: backAction,
+    });
   }
 
   async retrieveTransaction(id, delay = 0) {
     try {
+      const { tx: currentTx } = this.state;
       const { data } = await getTransactions(this.props.activePeer, { id });
       const tx = data[0] || {};
-      setTimeout(() => this.setState(prevState => ({
-        tx: merge(prevState.tx, tx),
-        refreshing: false,
-      })), delay);
+
+      // don't have any transaction passed from the navigation
+      // and couldn't find any with the id (example: navigating from a deep link)
+      if (!tx.id && !currentTx) {
+        this.setState({
+          error: true,
+        });
+      } else {
+        setTimeout(() => this.setState(prevState => ({
+          tx: merge(prevState.tx, tx),
+          refreshing: false,
+        })), delay);
+      }
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }
@@ -79,7 +112,15 @@ class TransactionDetail extends React.Component {
 
   render() {
     const { navigation, styles, theme } = this.props;
-    const { tx, refreshing } = this.state;
+    const { tx, error, refreshing } = this.state;
+
+    if (error) {
+      return (
+        <View style={[styles.container, styles.theme.container]}>
+          <P>EROL</P>
+        </View>
+      );
+    }
 
     if (!tx) {
       return (

--- a/src/utilities/deepLink.js
+++ b/src/utilities/deepLink.js
@@ -6,11 +6,11 @@ export default function deepLinkMapper(deepLinkURL) {
   }
 
   const { hostname, pathname, query } = new URL(deepLinkURL, true);
-  const path = hostname === 'main' ? pathname : hostname;
+  const path = hostname === 'main' ? `main${pathname}` : hostname;
 
   switch (path) {
     case 'wallet':
-    case '/transactions/send':
+    case 'main/transactions/send':
       return {
         name: 'Send',
         params: {
@@ -19,6 +19,14 @@ export default function deepLinkMapper(deepLinkURL) {
             amount: query.amount,
             reference: query.reference,
           },
+        },
+      };
+
+    case 'transactions':
+      return {
+        name: 'TxDetail',
+        params: {
+          txId: query.id,
         },
       };
 

--- a/src/utilities/deepLink.test.js
+++ b/src/utilities/deepLink.test.js
@@ -40,4 +40,18 @@ describe('Deep Link Handler', () => {
 
     expect(deepLinkMapper(url)).toEqual(expectedResult);
   });
+
+  it('handles urls with transactions path', () => {
+    const url = 'lisk://transactions?id=1';
+    const expectedResult = {
+      name: 'TxDetail',
+      params: {
+        query: {
+          txID: '1',
+        },
+      },
+    };
+
+    expect(deepLinkMapper(url)).toEqual(expectedResult);
+  });
 });

--- a/src/utilities/deepLink.test.js
+++ b/src/utilities/deepLink.test.js
@@ -46,9 +46,7 @@ describe('Deep Link Handler', () => {
     const expectedResult = {
       name: 'TxDetail',
       params: {
-        query: {
-          txID: '1',
-        },
+        txId: '1',
       },
     };
 


### PR DESCRIPTION
# What was the bug or feature?
Described in #561 

### How did I fix it?
- Updated deep link utility to handle `lisk://transactions?id=1` type of links
- Updated TxDetail component to handle edge cases could be caused by deep link navigation.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Try to navigate `lisk://transactions?id=15624657739400037237`

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
