### PR TITLE
Implement rejection message page in iMessage extension - Closes #566

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Lisk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/imessage/form/index.js
+++ b/src/components/imessage/form/index.js
@@ -10,12 +10,16 @@ import reg from '../../../constants/regex';
 import { colors } from '../../../constants/styleGuide';
 import Input from '../../toolBox/input';
 import Avatar from '../../avatar/index';
+import { Small } from '../../toolBox/typography';
 import styles from './styles';
 
 class LiskMessageExtension extends Component {
   state = {
     address: {
       value: '',
+      validity: -1,
+    },
+    amount: {
       validity: -1,
     },
     avatarPreview: false,
@@ -46,6 +50,7 @@ class LiskMessageExtension extends Component {
 
   changePicker = (itemValue, itemIndex) => {
     this.setState({
+      amount: { validity: -1 },
       num: this.state.num.map((item, index) =>
         (index === itemIndex ? itemValue : item)),
     });
@@ -69,27 +74,45 @@ class LiskMessageExtension extends Component {
     );
   }
 
+  send = () => {
+    const {
+      composeMessage, inputAddress,
+    } = this.props;
+
+    const { num, address } = this.state;
+
+    const amount = `${num[0]}${num[1]}.${num[2]}${num[3]}`;
+    if (parseFloat(amount) > 0) {
+      composeMessage({
+        address: address.value.length === 0 ? inputAddress : address,
+        amount,
+      });
+    } else {
+      this.setState({
+        amount: {
+          validity: 0,
+        },
+      });
+    }
+  };
+
   render() {
     const {
-      address, avatarPreview, num,
+      address, avatarPreview, num, amount,
     } = this.state;
 
     const {
-      composeMessage, inputAddress, keyBoardFocused, presentationStyle,
+      inputAddress, keyBoardFocused, presentationStyle,
     } = this.props;
 
     const data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    const send = () => composeMessage({
-      address: address.value.length === 0 ? inputAddress : address,
-      amount: `${num[0]}${num[1]}.${num[2]}${num[3]}`,
-    });
-
+    const pickerActiveColor = amount.validity === -1 ? colors.light.black : colors.light.actionRed;
 
     return (
       <Fragment>
         <View style={styles.rowContainer}>
           <View style={styles.innerContainer}>
-            <Text style={styles.pickerPoint}>.</Text>
+            <Text style={[styles.pickerPoint, { color: pickerActiveColor }]}>.</Text>
             {num.map((val, index) => (
               <Picker
                 key={index}
@@ -106,12 +129,19 @@ class LiskMessageExtension extends Component {
                     key={item}
                     label={item.toString()}
                     value={item}
-                    color={num[index] === item ? '#000' : 'rgba(0, 0, 0, 0.3)'}
+                    color={num[index] === item ? pickerActiveColor : 'rgba(0, 0, 0, 0.3)'}
                   />
                 ))}
               </Picker>
             ))}
           </View>
+        </View>
+        <View style={styles.errorContainer}>
+          <Small style={styles.pickerError}>
+            {
+              amount.validity === -1 ? '' : 'amount should be greater than 0'
+            }
+          </Small>
         </View>
         <View style={styles.addressContainer}>
           {
@@ -156,7 +186,7 @@ class LiskMessageExtension extends Component {
                 icon={'forward'}
                 color={colors.light.white}
                 iconSize={20}
-                onClick={send} /> : null
+                onClick={this.send} /> : null
           }
         </View>
         {
@@ -164,7 +194,7 @@ class LiskMessageExtension extends Component {
             <SecondaryButton
               style={{ marginTop: 20, marginLeft: 20, marginRight: 20 }}
               title="Request"
-              onClick={send}
+              onClick={this.send}
             /> : null
         }
 

--- a/src/components/imessage/form/styles.js
+++ b/src/components/imessage/form/styles.js
@@ -27,7 +27,7 @@ export default StyleSheet.create({
   innerContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 20,
+    marginTop: 10,
   },
   pickers: {
     height: 120,
@@ -52,6 +52,8 @@ export default StyleSheet.create({
   },
   addressContainer: {
     width: '100%',
+    marginTop: -15,
+    // backgroundColor: '#0ff',
   },
   addressInput: {
     height: 48,
@@ -82,5 +84,12 @@ export default StyleSheet.create({
   address: {
     fontWeight: 'bold',
     marginLeft: 10,
+  },
+  errorContainer: {
+    height: 17,
+  },
+  pickerError: {
+    textAlign: 'center',
+    color: colors.light.gray1,
   },
 });

--- a/src/components/imessage/index.js
+++ b/src/components/imessage/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import {
-  Text,
   ScrollView,
   NativeModules,
   NativeEventEmitter,
@@ -12,6 +11,7 @@ import ThemeContext from '../../contexts/theme';
 import Confirm from './imessageConfirm';
 import TxDetail from './txDetail';
 import Form from './form';
+import Rejected from './rejected';
 import DevSettings from './devSettings';
 
 const config = {
@@ -158,7 +158,7 @@ class LiskMessageExtension extends Component {
       if (message.url && activePeer) {
         switch (parsedData.state) {
           case 'rejected':
-            return <Text> this request has been rejected</Text>;
+            return <Rejected sharedData={parsedData} />;
           case 'transferred':
             return <TxDetail
               account={{ address: address.value }}
@@ -180,7 +180,6 @@ class LiskMessageExtension extends Component {
       <ThemeContext.Provider value="light">
         <ScrollView>
           {process.env.NODE_ENV === 'development' && <DevSettings />}
-
           {
             message.url ?
               <Element /> :

--- a/src/components/imessage/rejected/index.js
+++ b/src/components/imessage/rejected/index.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import { View, Image } from 'react-native';
+import { B } from '../../toolBox/typography';
+// import { colors } from '../../../constants/styleGuide';
+import styles from './styles';
+
+class Rejected extends Component {
+  state = {
+    errorMessage: false,
+    triggered: false,
+  }
+
+
+  render() {
+    const {
+      sharedData: { amount },
+    } = this.props;
+
+    return (
+      <View
+        style={styles.container}
+      >
+        <View style={styles.innerContainer}>
+          <Image source={{ uri: 'rejected' }} style={{ width: 250, height: 250 }} />
+          <B style={styles.description}>
+            Your request of {amount} LSK has been rejected.
+          </B>
+        </View>
+      </View>
+    );
+  }
+}
+
+export default Rejected;

--- a/src/components/imessage/rejected/styles.js
+++ b/src/components/imessage/rejected/styles.js
@@ -1,0 +1,24 @@
+import {
+  StyleSheet,
+} from "react-native"; // eslint-disable-line
+import { boxes, colors } from '../../../constants/styleGuide';
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: colors.light.white,
+    flex: 1,
+  },
+  innerContainer: {
+    marginTop: -30,
+    flexGrow: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flex: 1,
+    margin: boxes.boxPadding,
+  },
+  description: {
+    marginTop: -45,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
# What was the bug or feature?
It is described #566.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)


### How to test it?

1. request some tokens in an imessage message
2. reject that request
3. tap on the rejected message

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
