### PR TITLE
Update Scanner component to get permission copy from props - Closes #620

### DIFF
--- a/ios/Lisk/Info.plist
+++ b/ios/Lisk/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/LiskMessageExtension/Info.plist
+++ b/ios/LiskMessageExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/src/components/addBookmark/index.js
+++ b/src/components/addBookmark/index.js
@@ -212,6 +212,8 @@ class AddToBookmark extends React.Component {
           readFromCameraRoll={true}
           onQRCodeRead={this.onQRCodeRead}
           onClose={this.onCloseScanner}
+          permissionDialogTitle={t('Permission to use camera')}
+          permissionDialogMessage={t('Lisk needs to connect to your camera')}
         />
         <KeyboardAwareScrollView
             onSubmit={this.submitForm}

--- a/src/components/scanner/index.js
+++ b/src/components/scanner/index.js
@@ -3,7 +3,6 @@ import { AppState } from 'react-native';
 import Permissions from 'react-native-permissions';
 import { RNCamera } from 'react-native-camera';
 import QRCode from '@remobile/react-native-qrcode-local-image';
-import { translate } from 'react-i18next';
 import CameraAccess from './cameraAccess';
 import CameraOverlay from './cameraOverlay';
 import CameraRoll from './cameraRoll';
@@ -96,7 +95,7 @@ class Scanner extends React.Component {
   render() {
     const {
       styles, containerStyles: { scanner, cameraOverlay, cameraRoll } = {},
-      readFromCameraRoll, fullScreen, t,
+      readFromCameraRoll, fullScreen, permissionDialogTitle, permissionDialogMessage,
     } = this.props;
     const { camera, photo } = this.state;
     return (
@@ -113,8 +112,9 @@ class Scanner extends React.Component {
               type={RNCamera.Constants.Type.back}
               notAuthorizedView={<CameraAccess close={this.toggleCamera} fullScreen={fullScreen} />}
               pendingAuthorizationView={<CameraAccess close={this.toggleCamera} />}
-              permissionDialogTitle={t('Permission to use camera')}
-              permissionDialogMessage={t('Lisk needs to connect to your camera')} >
+              permissionDialogTitle={permissionDialogTitle}
+              permissionDialogMessage={permissionDialogMessage}
+            >
               {
                 readFromCameraRoll ?
                   <CameraOverlay
@@ -141,4 +141,4 @@ class Scanner extends React.Component {
   }
 }
 
-export default withTheme(translate()(Scanner), getStyles(), true);
+export default withTheme(Scanner, getStyles(), true);

--- a/src/components/send/confirm/index.js
+++ b/src/components/send/confirm/index.js
@@ -147,8 +147,9 @@ class Confirm extends React.Component {
           readFromCameraRoll={false}
           onQRCodeRead={this.onQRCodeRead}
           onClose={this.onCloseCamera}
+          permissionDialogTitle={t('Permission to use camera')}
+          permissionDialogMessage={t('Lisk needs to connect to your camera')}
         />
-
         <KeyboardAwareScrollView
           onSubmit={this.onSubmit}
           hasTabBar={true}

--- a/src/components/send/recipient/index.js
+++ b/src/components/send/recipient/index.js
@@ -183,6 +183,8 @@ class Recipient extends React.Component {
           navigation={navigation}
           readFromCameraRoll={true}
           onQRCodeRead={this.onQRCodeRead}
+          permissionDialogTitle={t('Permission to use camera')}
+          permissionDialogMessage={t('Lisk needs to connect to your camera')}
         />
         <KeyboardAwareScrollView
           onKeyboard={this.onKeyboardOpen}

--- a/src/components/signIn/form.js
+++ b/src/components/signIn/form.js
@@ -144,6 +144,8 @@ class Form extends React.Component {
           navigation={navigation}
           readFromCameraRoll={false}
           onQRCodeRead={this.onQRCodeRead}
+          permissionDialogTitle={t('Permission to use camera')}
+          permissionDialogMessage={t('Lisk needs to connect to your camera')}
         />
         <Animated.View
           style={[styles.titleContainer, styles.paddingBottom, { opacity }]}


### PR DESCRIPTION
# What was the bug or feature?
Described in #620 

### How did I fix it?
In order to prevent mis-forwarding ref issue, I have updated Scanner component to get permission dialog's title and message as a prop.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Try to open the scanner.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
