### PR TITLE
Add create/broadcast utilities for BTC transactions - Closes #606

### DIFF
--- a/src/utilities/api/account.js
+++ b/src/utilities/api/account.js
@@ -12,7 +12,7 @@ import getMappedFunction from './functionMapper';
  * @param {String} address
  * @returns {Promise<AccountSummary>}
  */
-const getSummary = (tokenType, address) => getMappedFunction(tokenType, 'account.getSummary')(address);
+const getSummary = (tokenType, address) => getMappedFunction(tokenType, 'account', 'getSummary')(address);
 
 /**
  * Extracts public key from passphrase for given token.
@@ -20,7 +20,7 @@ const getSummary = (tokenType, address) => getMappedFunction(tokenType, 'account
  * @param {String} passphrase
  * @returns {String}
  */
-const extractPublicKey = (tokenType, passphrase) => getMappedFunction(tokenType, 'account.extractPublicKey')(passphrase);
+const extractPublicKey = (tokenType, passphrase) => getMappedFunction(tokenType, 'account', 'extractPublicKey')(passphrase);
 
 /**
  * Extracts wallet address from passphrase for given token.
@@ -28,7 +28,7 @@ const extractPublicKey = (tokenType, passphrase) => getMappedFunction(tokenType,
  * @param {String} passphrase
  * @returns {String}
  */
-const extractAddress = (tokenType, passphrase) => getMappedFunction(tokenType, 'account.extractAddress')(passphrase);
+const extractAddress = (tokenType, passphrase) => getMappedFunction(tokenType, 'account', 'extractAddress')(passphrase);
 
 export default {
   getSummary,

--- a/src/utilities/api/btc/account.js
+++ b/src/utilities/api/btc/account.js
@@ -22,7 +22,7 @@ export const getSummary = address => new Promise(async (resolve, reject) => {
   }
 });
 
-const getDerivedPathFromSeed = (passphrase) => {
+export const getDerivedPathFromSeed = (passphrase) => {
   const seed = Lisk.passphrase.Mnemonic.mnemonicToSeed(passphrase);
   return bip32.fromSeed(seed, config.network).derivePath(config.derivationPath);
 };

--- a/src/utilities/api/btc/account.js
+++ b/src/utilities/api/btc/account.js
@@ -22,12 +22,12 @@ export const getSummary = address => new Promise(async (resolve, reject) => {
   }
 });
 
-export const getDerivedPathFromSeed = (passphrase) => {
+export const getDerivedPathFromPassphrase = (passphrase) => {
   const seed = Lisk.passphrase.Mnemonic.mnemonicToSeed(passphrase);
   return bip32.fromSeed(seed, config.network).derivePath(config.derivationPath);
 };
 
-export const extractPublicKey = passphrase => getDerivedPathFromSeed(passphrase).publicKey;
+export const extractPublicKey = passphrase => getDerivedPathFromPassphrase(passphrase).publicKey;
 
 export const extractAddress = (passphrase) => {
   const publicKey = extractPublicKey(passphrase);

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -1,6 +1,6 @@
 import bitcoin from 'bitcoinjs-lib';
 import config from '../../../../btc.config';
-import { extractAddress, getDerivedPathFromSeed } from './account';
+import { extractAddress, getDerivedPathFromPassphrase } from './account';
 import { merge } from '../../helpers';
 
 /**
@@ -200,7 +200,7 @@ export const create = ({
     txb.addOutput(senderAddress, change);
 
     // Sign inputs
-    const derivedPath = getDerivedPathFromSeed(passphrase);
+    const derivedPath = getDerivedPathFromPassphrase(passphrase);
     const keyPair = bitcoin.ECPair.fromWIF(derivedPath.toWIF(), config.network);
     for (let i = 0; i < txOutsToConsume.length; i++) {
       txb.sign(i, keyPair);

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -1,6 +1,7 @@
 import bitcoin from 'bitcoinjs-lib';
 import config from '../../../../btc.config';
 import { extractAddress, getDerivedPathFromSeed } from './account';
+import { merge } from '../../helpers';
 
 /**
  * Normalizes transaction data retrieved from Blockchain.info API
@@ -236,6 +237,26 @@ export const create = ({
     }
 
     resolve(txb.build().toHex());
+  } catch (error) {
+    reject(error);
+  }
+});
+
+export const broadcast = transaction => new Promise(async (resolve, reject) => {
+  try {
+    const body = new FormData();
+    body.append('tx', transaction);
+
+    const response = await fetch(`${config.url}/pushtx`, merge(config.requestOptions, {
+      method: 'POST',
+      body,
+    }));
+
+    if (response.ok) {
+      resolve(response.body);
+    } else {
+      reject(response.body);
+    }
   } catch (error) {
     reject(error);
   }

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -118,7 +118,7 @@ const calculateTransactionFee = ({
  * @param {String} address
  * @returns {Promise<Array>}
  */
-export const getUnspentOuts = address => new Promise(async (resolve, reject) => {
+export const getUnspentTransactionOutputs = address => new Promise(async (resolve, reject) => {
   try {
     const response = await fetch(`${config.url}/unspent?active=${address}`);
     const json = await response.json();
@@ -141,7 +141,7 @@ export const create = ({
 }) => new Promise(async (resolve, reject) => {
   try {
     const senderAddress = extractAddress(passphrase);
-    const unspentTxOuts = await exports.getUnspentOuts(senderAddress);
+    const unspentTxOuts = await exports.getUnspentTransactionOutputs(senderAddress);
 
     // Estimate total cost (currently estimates max cost by assuming the worst case)
     const estimatedMinerFee = calculateTransactionFee({

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -377,4 +377,37 @@ describe('api/btc/transactions', () => {
       expect(tx).toBeTruthy();
     });
   });
+
+  describe('broadcast', () => {
+    const txHex = '0200000001c156742387e44c7906091bc08d382951bfe1c9dc703856010e08ef803f90dafe000000006b483045022100d1dde0fe78b5e20d570348eca954336ccdfd8b25cb150203977e690b3dbc71eb02205f45fde27ded53dec38ca96530722f11bd4c0da96acd698e3d826395a57cfcac012102cd9e67acba4950837bb773b6d05f54ba0594aa4863b9dcb0dfe0bb94d14c56c2ffffffff029e000000000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac180d1800000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac00000000';
+    beforeEach(() => fetchMock.reset());
+
+    it('resolves correctly', async () => {
+      const successResponse = 'Transaction Submitted';
+      fetchMock.once('*', successResponse);
+      const result = await transactions.broadcast(txHex);
+      expect(result).toEqual(successResponse);
+    });
+
+    it('handles non-500 errors', async () => {
+      const errorResponse = 'Transaction already exists';
+      fetchMock.once('*', { status: 400, body: errorResponse });
+
+      try {
+        await transactions.broadcast(txHex);
+      } catch (error) {
+        expect(error).toEqual(errorResponse);
+      }
+    });
+
+    it('handles errors', async () => {
+      fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
+
+      try {
+        await transactions.broadcast(txHex);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+  });
 });

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -1,22 +1,117 @@
+import bitcoin from 'bitcoinjs-lib';
 import fetchMock from 'fetch-mock';
 import * as transactions from './transactions';
+import config from '../../../../btc.config';
 
-const address = '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve';
+const passphrase = 'say width dwarf confirm rule party pact iron edge dignity wish direct';
+
+const address = {
+  mainnet: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
+  testnet: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+  testnetRecipient: 'mgKwQFVCEN2enQtzgqrzCxWv5WH6VAyLXa',
+};
+
 const response = {
-  hash160: '4f6a9f245359d3b3441fcd22117c78466039caba',
-  address: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-  n_tx: 2,
-  total_received: 401724600,
-  total_sent: 401724600,
-  final_balance: 0,
-  txs: [
-    {
-      ver: 1,
-      inputs: [
-        {
-          sequence: 4294967295,
-          witness: '',
-          prev_out: {
+  getTransactions: {
+    hash160: '4f6a9f245359d3b3441fcd22117c78466039caba',
+    address: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
+    n_tx: 2,
+    total_received: 401724600,
+    total_sent: 401724600,
+    final_balance: 0,
+    txs: [
+      {
+        ver: 1,
+        inputs: [
+          {
+            sequence: 4294967295,
+            witness: '',
+            prev_out: {
+              spent: true,
+              spending_outpoints: [
+                {
+                  tx_index: 411031256,
+                  n: 0,
+                },
+              ],
+              tx_index: 409136088,
+              type: 0,
+              addr: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
+              value: 401724600,
+              n: 1,
+              script: '76a9144f6a9f245359d3b3441fcd22117c78466039caba88ac',
+            },
+            script: '473044022078ca6d574cb3272fa7dfb28fd31a1acd9099dd521c1d4e7accb2086f60ad484202207b4131d72f6caf3a2c7758771b03e1b071cf0d8ee43f719bae2673ca79a2b7d701210305dbc31667a16d565c6f37da58ec37230f241eacd5950137df7b5a08996e6730',
+          },
+        ],
+        weight: 756,
+        block_height: 560808,
+        relayed_by: '0.0.0.0',
+        out: [
+          {
+            spent: false,
+            tx_index: 411031256,
+            type: 0,
+            addr: '3AoZ4rm7qZWcCzNHMDhh41zJE5LNfr7Gx2',
+            value: 401723000,
+            n: 0,
+            script: 'a91463f59fff9f9f13075e445d1ee6f864d0f375f91f87',
+          },
+        ],
+        lock_time: 0,
+        result: 0,
+        size: 189,
+        block_index: 1748075,
+        time: 1548876059,
+        tx_index: 411031256,
+        vin_sz: 1,
+        hash: 'a146763b49a6181e3fbc611def63af13ac2c08a0d97c80e64c93e8e083110aa9',
+        vout_sz: 1,
+      },
+      {
+        ver: 1,
+        inputs: [
+          {
+            sequence: 4294967293,
+            witness: '',
+            prev_out: {
+              spent: true,
+              spending_outpoints: [
+                {
+                  tx_index: 409136088,
+                  n: 0,
+                },
+              ],
+              tx_index: 409075879,
+              type: 0,
+              addr: '1BrQvwTsDntfBAowYrqKq98MYY3dUNjnU3',
+              value: 774865158,
+              n: 1,
+              script: '76a91477099d9f2157a80c403dcb4c87f20b29f04506f088ac',
+            },
+            script: '483045022100e06322de8e7fc608084a2b7f83da88b6474cd4b7ef52b8cf53258adc7cb8814b022032dba7068cab1cc7bbb561ca17c61335642627d98bae7798283f75920fe03204012102a9059f4e87767f7e0ea5efceb33fc4cb8f6139a8c251bf8798e873d96105bef2',
+          },
+        ],
+        weight: 904,
+        block_height: 559919,
+        relayed_by: '0.0.0.0',
+        out: [
+          {
+            spent: true,
+            spending_outpoints: [
+              {
+                tx_index: 411616078,
+                n: 1,
+              },
+            ],
+            tx_index: 409136088,
+            type: 0,
+            addr: '14k18ngzkYcPnriyTNMaSnNgQBCRsKunYM',
+            value: 373138298,
+            n: 0,
+            script: '76a914290a6033f096917b3609621b9407aed043d01c1e88ac',
+          },
+          {
             spent: true,
             spending_outpoints: [
               {
@@ -31,104 +126,47 @@ const response = {
             n: 1,
             script: '76a9144f6a9f245359d3b3441fcd22117c78466039caba88ac',
           },
-          script: '473044022078ca6d574cb3272fa7dfb28fd31a1acd9099dd521c1d4e7accb2086f60ad484202207b4131d72f6caf3a2c7758771b03e1b071cf0d8ee43f719bae2673ca79a2b7d701210305dbc31667a16d565c6f37da58ec37230f241eacd5950137df7b5a08996e6730',
-        },
-      ],
-      weight: 756,
-      block_height: 560808,
-      relayed_by: '0.0.0.0',
-      out: [
-        {
-          spent: false,
-          tx_index: 411031256,
-          type: 0,
-          addr: '3AoZ4rm7qZWcCzNHMDhh41zJE5LNfr7Gx2',
-          value: 401723000,
-          n: 0,
-          script: 'a91463f59fff9f9f13075e445d1ee6f864d0f375f91f87',
-        },
-      ],
-      lock_time: 0,
-      result: 0,
-      size: 189,
-      block_index: 1748075,
-      time: 1548876059,
-      tx_index: 411031256,
-      vin_sz: 1,
-      hash: 'a146763b49a6181e3fbc611def63af13ac2c08a0d97c80e64c93e8e083110aa9',
-      vout_sz: 1,
-    },
-    {
-      ver: 1,
-      inputs: [
-        {
-          sequence: 4294967293,
-          witness: '',
-          prev_out: {
-            spent: true,
-            spending_outpoints: [
-              {
-                tx_index: 409136088,
-                n: 0,
-              },
-            ],
-            tx_index: 409075879,
-            type: 0,
-            addr: '1BrQvwTsDntfBAowYrqKq98MYY3dUNjnU3',
-            value: 774865158,
-            n: 1,
-            script: '76a91477099d9f2157a80c403dcb4c87f20b29f04506f088ac',
-          },
-          script: '483045022100e06322de8e7fc608084a2b7f83da88b6474cd4b7ef52b8cf53258adc7cb8814b022032dba7068cab1cc7bbb561ca17c61335642627d98bae7798283f75920fe03204012102a9059f4e87767f7e0ea5efceb33fc4cb8f6139a8c251bf8798e873d96105bef2',
-        },
-      ],
-      weight: 904,
-      block_height: 559919,
-      relayed_by: '0.0.0.0',
-      out: [
-        {
-          spent: true,
-          spending_outpoints: [
-            {
-              tx_index: 411616078,
-              n: 1,
-            },
-          ],
-          tx_index: 409136088,
-          type: 0,
-          addr: '14k18ngzkYcPnriyTNMaSnNgQBCRsKunYM',
-          value: 373138298,
-          n: 0,
-          script: '76a914290a6033f096917b3609621b9407aed043d01c1e88ac',
-        },
-        {
-          spent: true,
-          spending_outpoints: [
-            {
-              tx_index: 411031256,
-              n: 0,
-            },
-          ],
-          tx_index: 409136088,
-          type: 0,
-          addr: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-          value: 401724600,
-          n: 1,
-          script: '76a9144f6a9f245359d3b3441fcd22117c78466039caba88ac',
-        },
-      ],
-      lock_time: 559918,
-      result: -401724600,
-      size: 226,
-      rbf: true,
-      block_index: 1745627,
-      time: 1548345462,
-      tx_index: 409136088,
-      vin_sz: 1,
-      hash: 'e85812a1ce720f9bcda387465a7bd2c2bbfa8b62ce5220f2df1a3017cbda70e4',
-      vout_sz: 2,
-    },
-  ],
+        ],
+        lock_time: 559918,
+        result: -401724600,
+        size: 226,
+        rbf: true,
+        block_index: 1745627,
+        time: 1548345462,
+        tx_index: 409136088,
+        vin_sz: 1,
+        hash: 'e85812a1ce720f9bcda387465a7bd2c2bbfa8b62ce5220f2df1a3017cbda70e4',
+        vout_sz: 2,
+      },
+    ],
+  },
+  getUnspentOuts: {
+    unspent_outputs: [
+      {
+        tx_hash: 'c156742387e44c7906091bc08d382951bfe1c9dc703856010e08ef803f90dafe',
+        tx_hash_big_endian: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+        tx_index: 289209213,
+        tx_output_n: 0,
+        script: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+        value: 1580000,
+        value_hex: '181be0',
+        confirmations: 1044,
+      },
+    ],
+  },
+  getMinerFees: {
+    hourFee: 20,
+    halfHourFee: 40,
+    fastestFee: 80,
+  },
+};
+
+const normalizedData = {
+  minerFees: {
+    low: 20,
+    medium: 40,
+    high: 80,
+  },
 };
 
 describe('api/btc/transactions', () => {
@@ -162,10 +200,11 @@ describe('api/btc/transactions', () => {
     beforeEach(() => fetchMock.reset());
 
     it('resolves correctly for single transaction', async () => {
+      const tx = response.getTransactions.txs[0];
       transactions.getLatestBlockHeight.mockResolvedValueOnce(600000);
-      fetchMock.once('*', response.txs[0]);
-      const id = response.txs[0].hash;
-      const result = await transactions.get({ address, id });
+      fetchMock.once('*', tx);
+      const id = tx.hash;
+      const result = await transactions.get({ address: address.mainnet, id });
       expect(result).toEqual({
         data: [
           {
@@ -188,8 +227,8 @@ describe('api/btc/transactions', () => {
 
     it('resolves correctly for multiple transactions', async () => {
       transactions.getLatestBlockHeight.mockResolvedValueOnce(0);
-      fetchMock.once('*', response);
-      const result = await transactions.get({ address });
+      fetchMock.once('*', response.getTransactions);
+      const result = await transactions.get({ address: address.mainnet });
       expect(result).toEqual({
         data: [
           {
@@ -240,6 +279,102 @@ describe('api/btc/transactions', () => {
       } catch (error) {
         expect(error).toBeTruthy();
       }
+    });
+  });
+
+  describe('getMinerFees', () => {
+    beforeEach(() => fetchMock.reset());
+
+    it('resolves correctly', async () => {
+      fetchMock.once('*', response.getMinerFees);
+      const result = await transactions.getMinerFees();
+      expect(result).toEqual(normalizedData.minerFees);
+    });
+
+    it('handles non-500 errors', async () => {
+      const errorResponse = { message: 'Error' };
+      fetchMock.once('*', { status: 400, body: errorResponse });
+
+      try {
+        await transactions.getMinerFees();
+      } catch (error) {
+        expect(error).toEqual(errorResponse);
+      }
+    });
+
+    it('handles errors', async () => {
+      fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
+
+      try {
+        await transactions.getMinerFees();
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+  });
+
+  describe('getUnspentOuts', () => {
+    beforeEach(() => fetchMock.reset());
+
+    it('resolves correctly', async () => {
+      fetchMock.once('*', response.getUnspentOuts);
+      const result = await transactions.getUnspentOuts(address.mainnet);
+      expect(result).toEqual(response.getUnspentOuts.unspent_outputs);
+    });
+
+    it('handles non-500 errors', async () => {
+      const errorResponse = { message: 'Error' };
+      fetchMock.once('*', { status: 400, body: errorResponse });
+
+      try {
+        await transactions.getUnspentOuts(address.mainnet);
+      } catch (error) {
+        expect(error).toEqual(errorResponse);
+      }
+    });
+
+    it('handles errors', async () => {
+      fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
+
+      try {
+        await transactions.getUnspentOuts(address.mainnet);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+  });
+
+  describe('create', () => {
+    beforeAll(() => {
+      config.network = bitcoin.networks.testnet;
+
+      transactions.getMinerFees = jest.fn();
+      transactions.getMinerFees.mockResolvedValue(normalizedData.minerFees);
+
+      transactions.getUnspentOuts = jest.fn();
+      transactions.getUnspentOuts.mockResolvedValue(response.getUnspentOuts.unspent_outputs);
+    });
+
+    it('throws error for insufficient balance', async () => {
+      try {
+        await transactions.create({
+          passphrase,
+          recipientAddress: address.testnetRecipient,
+          amount: 1000000000,
+        });
+      } catch (error) {
+        expect(error.message).toBe('Insufficient (estimated) balance');
+      }
+    });
+
+    it('creates a valid transaction', async () => {
+      const tx = await transactions.create({
+        passphrase,
+        recipientAddress: address.testnetRecipient,
+        amount: 1000000,
+      });
+
+      expect(tx).toBeTruthy();
     });
   });
 });

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -140,7 +140,7 @@ const response = {
       },
     ],
   },
-  getUnspentOuts: {
+  getUnspentTransactionOutputs: {
     unspent_outputs: [
       {
         tx_hash: 'c156742387e44c7906091bc08d382951bfe1c9dc703856010e08ef803f90dafe',
@@ -270,13 +270,13 @@ describe('api/btc/transactions', () => {
     });
   });
 
-  describe('getUnspentOuts', () => {
+  describe('getUnspentTransactionOutputs', () => {
     beforeEach(() => fetchMock.reset());
 
     it('resolves correctly', async () => {
-      fetchMock.once('*', response.getUnspentOuts);
-      const result = await transactions.getUnspentOuts(address.mainnet);
-      expect(result).toEqual(response.getUnspentOuts.unspent_outputs);
+      fetchMock.once('*', response.getUnspentTransactionOutputs);
+      const result = await transactions.getUnspentTransactionOutputs(address.mainnet);
+      expect(result).toEqual(response.getUnspentTransactionOutputs.unspent_outputs);
     });
 
     it('handles non-500 errors', async () => {
@@ -284,7 +284,7 @@ describe('api/btc/transactions', () => {
       fetchMock.once('*', { status: 400, body: errorResponse });
 
       try {
-        await transactions.getUnspentOuts(address.mainnet);
+        await transactions.getUnspentTransactionOutputs(address.mainnet);
       } catch (error) {
         expect(error).toEqual(errorResponse);
       }
@@ -294,7 +294,7 @@ describe('api/btc/transactions', () => {
       fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
 
       try {
-        await transactions.getUnspentOuts(address.mainnet);
+        await transactions.getUnspentTransactionOutputs(address.mainnet);
       } catch (error) {
         expect(error).toBeTruthy();
       }
@@ -305,8 +305,9 @@ describe('api/btc/transactions', () => {
     beforeAll(() => {
       config.network = bitcoin.networks.testnet;
 
-      transactions.getUnspentOuts = jest.fn();
-      transactions.getUnspentOuts.mockResolvedValue(response.getUnspentOuts.unspent_outputs);
+      transactions.getUnspentTransactionOutputs = jest.fn();
+      transactions.getUnspentTransactionOutputs
+        .mockResolvedValue(response.getUnspentTransactionOutputs.unspent_outputs);
     });
 
     it('throws error for insufficient balance', async () => {

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -154,20 +154,8 @@ const response = {
       },
     ],
   },
-  getMinerFees: {
-    hourFee: 20,
-    halfHourFee: 40,
-    fastestFee: 80,
-  },
 };
 
-const normalizedData = {
-  minerFees: {
-    low: 20,
-    medium: 40,
-    high: 80,
-  },
-};
 
 describe('api/btc/transactions', () => {
   describe('getLatestBlockHeight', () => {
@@ -282,37 +270,6 @@ describe('api/btc/transactions', () => {
     });
   });
 
-  describe('getMinerFees', () => {
-    beforeEach(() => fetchMock.reset());
-
-    it('resolves correctly', async () => {
-      fetchMock.once('*', response.getMinerFees);
-      const result = await transactions.getMinerFees();
-      expect(result).toEqual(normalizedData.minerFees);
-    });
-
-    it('handles non-500 errors', async () => {
-      const errorResponse = { message: 'Error' };
-      fetchMock.once('*', { status: 400, body: errorResponse });
-
-      try {
-        await transactions.getMinerFees();
-      } catch (error) {
-        expect(error).toEqual(errorResponse);
-      }
-    });
-
-    it('handles errors', async () => {
-      fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
-
-      try {
-        await transactions.getMinerFees();
-      } catch (error) {
-        expect(error).toBeTruthy();
-      }
-    });
-  });
-
   describe('getUnspentOuts', () => {
     beforeEach(() => fetchMock.reset());
 
@@ -348,9 +305,6 @@ describe('api/btc/transactions', () => {
     beforeAll(() => {
       config.network = bitcoin.networks.testnet;
 
-      transactions.getMinerFees = jest.fn();
-      transactions.getMinerFees.mockResolvedValue(normalizedData.minerFees);
-
       transactions.getUnspentOuts = jest.fn();
       transactions.getUnspentOuts.mockResolvedValue(response.getUnspentOuts.unspent_outputs);
     });
@@ -361,6 +315,7 @@ describe('api/btc/transactions', () => {
           passphrase,
           recipientAddress: address.testnetRecipient,
           amount: 1000000000,
+          dynamicFeePerByte: 40,
         });
       } catch (error) {
         expect(error.message).toBe('Insufficient (estimated) balance');
@@ -372,6 +327,7 @@ describe('api/btc/transactions', () => {
         passphrase,
         recipientAddress: address.testnetRecipient,
         amount: 1000000,
+        dynamicFeePerByte: 40,
       });
 
       expect(tx).toBeTruthy();

--- a/src/utilities/api/functionMapper.js
+++ b/src/utilities/api/functionMapper.js
@@ -25,22 +25,21 @@ const resourceMap = {
 /**
  * Extracts related account API utility for given tokenType and map address.
  * @param {String} tokenType
- * @param {String} mapAddress Valid key path for a utility function, eg: account.getSummary
+ * @param {String} resourceName - key path for the resource, eg: account
+ * @param {String} functionName - key path for the utility function, eg: getSummary
  * @returns {Function}
  */
-const getMappedFunction = (tokenType, mapAddress) => {
-  const [resource, method] = mapAddress.split('.');
-
+const getMappedFunction = (tokenType, resourceName, functionName) => {
   try {
-    const fn = resourceMap[tokenType][resource][method];
+    const fn = resourceMap[tokenType][resourceName][functionName];
 
     if (typeof fn === 'function') {
       return fn;
     }
 
-    throw new Error(`${tokenType} doesn't match a function for ${mapAddress}.`);
+    throw new Error(`${tokenType} doesn't match a function for ${resourceName}.${functionName}.`);
   } catch (error) {
-    throw new Error(`Invalid mapper path for ${tokenType} - ${mapAddress}.`);
+    throw new Error(`Invalid mapper path for ${tokenType} - ${resourceName}.${functionName}.`);
   }
 };
 

--- a/src/utilities/api/functionMapper.test.js
+++ b/src/utilities/api/functionMapper.test.js
@@ -3,12 +3,12 @@ import getMappedFunction from './functionMapper';
 
 describe('api/functionMapper', () => {
   it('maps existing functions correctly', () => {
-    const result = getMappedFunction(tokenMap.BTC.key, 'account.getSummary');
+    const result = getMappedFunction(tokenMap.BTC.key, 'account', 'getSummary');
     expect(result).toBeDefined();
   });
 
   it('throws error for non-existing functions', () => {
-    expect(() => getMappedFunction(tokenMap.LSK.key, 'account.unMappableFunction')).toThrow();
+    expect(() => getMappedFunction(tokenMap.LSK.key, 'account', 'unMappableFunction')).toThrow();
   });
 
   it('throws error for invalid path', () => {

--- a/src/utilities/api/service.js
+++ b/src/utilities/api/service.js
@@ -11,7 +11,7 @@ import getMappedFunction from './functionMapper';
  * @param {String} tokenType
  * @returns {Promise<PriceTicker>}
  */
-const getPriceTicker = tokenType => getMappedFunction(tokenType, 'service.getPriceTicker')();
+const getPriceTicker = tokenType => getMappedFunction(tokenType, 'service', 'getPriceTicker')();
 
 /**
  * Contains dynamic fee rates for a token to indicate processing speed on the blockchain.
@@ -26,7 +26,7 @@ const getPriceTicker = tokenType => getMappedFunction(tokenType, 'service.getPri
  * @param {String} tokenType
  * @returns {Promise<DynamicFees>}
  */
-const getDynamicFees = tokenType => getMappedFunction(tokenType, 'service.getDynamicFees')();
+const getDynamicFees = tokenType => getMappedFunction(tokenType, 'service', 'getDynamicFees')();
 
 export default {
   getPriceTicker,

--- a/src/utilities/api/transactions.js
+++ b/src/utilities/api/transactions.js
@@ -32,7 +32,7 @@ import getMappedFunction from './functionMapper';
  * @param {Number} data.offset
  * @returns {Promise<TransactionsResponse>}
  */
-const get = (tokenType, data) => getMappedFunction(tokenType, 'transactions.get')(data);
+const get = (tokenType, data) => getMappedFunction(tokenType, 'transactions', 'get')(data);
 
 /**
  * Creates a raw, ready-to-broadcast transaction data with given payload.
@@ -46,7 +46,7 @@ const get = (tokenType, data) => getMappedFunction(tokenType, 'transactions.get'
  * @param {Number} data.dynamicFeePerByte - rate of miner/dynamic fee per byte, only used for BTC.
  * @returns {Promise}
  */
-const create = (tokenType, data) => getMappedFunction(tokenType, 'transactions.create')(data);
+const create = (tokenType, data) => getMappedFunction(tokenType, 'transactions', 'create')(data);
 
 /**
  * Broadcasts a transaction to the specified token's blockchain.
@@ -54,7 +54,7 @@ const create = (tokenType, data) => getMappedFunction(tokenType, 'transactions.c
  * @param {Object} transaction
  * @returns {Promise}
  */
-const broadcast = (tokenType, transaction) => getMappedFunction(tokenType, 'transactions.broadcast')(transaction);
+const broadcast = (tokenType, transaction) => getMappedFunction(tokenType, 'transactions', 'broadcast')(transaction);
 
 export default {
   get,

--- a/src/utilities/api/transactions.js
+++ b/src/utilities/api/transactions.js
@@ -41,8 +41,9 @@ const get = (tokenType, data) => getMappedFunction(tokenType, 'transactions.get'
  * @param {String} data.passphrase
  * @param {String} data.recipientAddress
  * @param {String} data.amount
- * @param {String} data.secondPassphrase required if registered, only used for LSK.
- * @param {String} data.data custom data field, only used for LSK.
+ * @param {String} data.secondPassphrase - required if registered, only used for LSK.
+ * @param {String} data.data - custom data field, only used for LSK.
+ * @param {Number} data.dynamicFeePerByte - rate of miner/dynamic fee per byte, only used for BTC.
  * @returns {Promise}
  */
 const create = (tokenType, data) => getMappedFunction(tokenType, 'transactions.create')(data);


### PR DESCRIPTION
# What was the bug or feature?
Described in #606 

### How did I fix it?
- Added API utility for fetching unspent tx outputs for BTC
- Added create transaction utility for BTC
- Added broadcast transaction utility for BTC

## Type of change
- Enhancement (a non-breaking change which adds functionality)

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
