### PR TITLE
Update settings middleware to verify device locale - Closes #633

### DIFF
--- a/src/store/middlewares/settings.js
+++ b/src/store/middlewares/settings.js
@@ -2,6 +2,7 @@ import actionTypes from '../../constants/actions';
 import { storeSettings } from '../../utilities/storage';
 import { deviceLocale } from '../../utilities/device';
 import i18n from '../../../locales';
+import { languageKeys } from '../../constants/languages';
 
 const settingsMiddleware = store => next => (action) => {
   switch (action.type) {
@@ -10,9 +11,12 @@ const settingsMiddleware = store => next => (action) => {
         action.data.language = deviceLocale();
       }
 
-      if (action.data.language !== 'en') {
+      if (action.data.language !== 'en' && languageKeys.includes(action.data.language)) {
         i18n.changeLanguage(action.data.language);
+      } else {
+        action.data.language = 'en';
       }
+
       next(action);
       break;
     case actionTypes.settingsUpdated:


### PR DESCRIPTION
# What was the bug or feature?
Described in #633 

### How did I fix it?
- Added a security check to settings middleware to make sure retrieved device locale doesn't break the app.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
- Update your region something other than EN / DE. 
- Re-install the app
- Try to open settings page

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
