### PR TITLE
Update iMessage/Form to securely handle changes in address - Closes #649

### DIFF
--- a/ios/Lisk/Info.plist
+++ b/ios/Lisk/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.1</string>
+	<string>0.11.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/LiskMessageExtension/Info.plist
+++ b/ios/LiskMessageExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.1</string>
+	<string>0.11.2</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>2</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lisk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "description": "The Lisk official mobile wallet",
   "homepage": "https://github.com/LiskHQ/lisk-mobile",

--- a/src/components/imessage/form/index.js
+++ b/src/components/imessage/form/index.js
@@ -33,12 +33,27 @@ class LiskMessageExtension extends Component {
     },
   };
 
+
+  componentDidMount() {
+    const { MessagesEvents, inputAddress } = this.props;
+    MessagesEvents.addListener('didStartSendingMessage', this.onStartSendingMessage);
+    this.setAddress(inputAddress.value);
+  }
+
+  onStartSendingMessage = () => {
+    this.setState({
+      num: [0, 0, 0, 0],
+    }, () => this.setAddress(this.props.inputAddress.value));
+  }
+
   setAddress = (value) => {
     clearTimeout(this.avatarPreviewTimeout);
     const validity = this.validator.address(value);
+
     if (validity === 0) {
       this.setAvatarPreviewTimeout();
     }
+
     this.setState({
       address: {
         value,
@@ -64,21 +79,8 @@ class LiskMessageExtension extends Component {
     }, 300);
   };
 
-  componentDidMount() {
-    this.props.MessagesEvents.addListener(
-      'didStartSendingMessage',
-      () => this.setState({
-        num: [0, 0, 0, 0],
-        address: this.props.inputAddress,
-      }),
-    );
-  }
-
   send = () => {
-    const {
-      composeMessage, inputAddress,
-    } = this.props;
-
+    const { composeMessage, inputAddress } = this.props;
     const { num, address } = this.state;
     const firstDigit = (parseInt(num[0], 10) > 0) ? num[0] : '';
 
@@ -152,7 +154,7 @@ class LiskMessageExtension extends Component {
         </View>
         <View style={styles.addressContainer}>
           {
-            avatarPreview || this.props.avatarPreview ?
+            avatarPreview && this.props.avatarPreview ?
               <Avatar
                 style={styles.avatar}
                 address={address.value || inputAddress.value}


### PR DESCRIPTION
# What was the bug or feature?
Described in #649 

### How did I fix it?
Updated the form component within our iMessage extension to handle address changes in a more secure way in order to prevent crashes.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Try to reproduce buggy scenario explained in #649 


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
