### PR TITLE
Fix the asset selector on settings screen - Closes #650

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -175,5 +175,6 @@
   "OK": "OK",
   "Sign in using bioAuth": "Melde dich mit {{sensorType}} an",
   "You don't have any bookmarks. Start adding then through the sending process.": "Du hast noch keine Lesezeichen. Im Sendevorgang kannst du sie hinzufügen.",
-  "Use bioAuth": "{{sensorType}} benutzen"
+  "Use bioAuth": "{{sensorType}} benutzen",
+  "Manage assets": ""
 }

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -174,5 +174,6 @@
   "For ease of sign in": "For ease of sign in",
   "OK": "OK",
   "Sign in using bioAuth": "Sign in using {{sensorType}}",
-  "Use bioAuth": "Use {{sensorType}}"
+  "Use bioAuth": "Use {{sensorType}}",
+  "Manage assets": "Manage assets"
 }

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -206,7 +206,7 @@ const MainStack = StackNavigator(
     ManageAssets: {
       screen: ManageAssets,
       navigationOptions: {
-        title: 'Manage assets',
+        title: t('Manage assets'),
         headerTitle: HeaderTitle,
         headerRight: <TokenSwitcher />,
         headerLeft: HeaderBackButton,

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -150,12 +150,21 @@ class Settings extends React.Component {
                 icon='currency'
                 iconSize={20}
                 title={t('Currency')}
-                target='ManageAssets'
+                target='CurrencySelection'
                 targetStateLabel={
                   <P style={{ color: colors[theme].gray1 }}>
                     {settings.currency}
                   </P>
                 }
+              />
+            </View>
+            <View style={[styles.item, styles.theme.item]}>
+              <ItemTitle
+                navigation={navigation}
+                icon='manage-assets'
+                iconSize={20}
+                title={t('Manage assets')}
+                target='ManageAssets'
               />
             </View>
             <View style={[styles.item, styles.theme.item]}>


### PR DESCRIPTION
# What was the bug or feature?
Described in #650 

### How did I fix it?
Updated settings page to have correct targets for list items.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Try to trigger `Manage assets` and `Currency selection` in the Settings page.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
