### PR TITLE
Update asset selection page to keep LSK always enabled - Closes #651

### DIFF
--- a/src/components/manageAssets/index.js
+++ b/src/components/manageAssets/index.js
@@ -44,17 +44,31 @@ class ManageAssets extends React.Component {
               <View style={[styles.itemContainer, styles.theme.itemContainer]}>
                 <View style={{ flexDirection: 'row' }}>
                   <View style={styles[`${item}Container`]}>
-                    <Icon color='#fff' name={tokenMap[item].icon} size={25} style={{ textAlign: 'center' }} />
+                    <Icon
+                      color='#fff'
+                      name={tokenMap[item].icon}
+                      size={25}
+                      style={{ textAlign: 'center' }}
+                    />
                   </View>
+
                   <B style={[styles.itemLabel, styles.theme.itemLabel]}>
                     {tokenMap[item].label}
                   </B>
                 </View>
-                <View style={styles.switch}>
-                  <SwitchButton
-                    value={token.list[tokenMap[item].key]}
-                    theme={theme}
-                    onSyncPress={(value) => { this.onSelect(value, tokenMap[item].key); }} />
+
+                <View>
+                  {item === tokenMap.LSK.key ? (
+                    <P style={styles.theme.description}>
+                      Primary
+                    </P>
+                  ) : (
+                    <SwitchButton
+                      value={token.list[tokenMap[item].key]}
+                      theme={theme}
+                      onSyncPress={(value) => { this.onSelect(value, tokenMap[item].key); }}
+                    />
+                  )}
                 </View>
               </View>
             </View>

--- a/src/store/reducers/settings.js
+++ b/src/store/reducers/settings.js
@@ -9,7 +9,7 @@ export const INITIAL_STATE = {
   currency: currencyKeys[0],
   token: {
     active: tokenKeys[0],
-    list: tokenKeys.reduce((acc, key) => { acc[key] = false; return acc; }, {}),
+    list: tokenKeys.reduce((acc, key) => { acc[key] = true; return acc; }, {}),
   },
 };
 


### PR DESCRIPTION
# What was the bug or feature?
Described in #651 

### How did I fix it?
- Update settings reducer to have all tokens enabled by default
- Update asset selection page to keep LSK enabled

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Check Manage assets page by opening it from settings.
- Note that due to a bug which is fixed on #654 you need to use Currency item to open Manage assets page 😅 


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
