### PR TITLE
Refactor the validation of Send/SecondPassphrase step - Closes #670

### DIFF
--- a/src/components/send/secondPassphrase/index.js
+++ b/src/components/send/secondPassphrase/index.js
@@ -24,7 +24,6 @@ class SecondPassphrase extends React.Component {
   state = {
     secondPassphrase: {
       value: devDefaultSecondPass,
-      validity: devDefaultSecondPass ? validatePassphrase(devDefaultSecondPass) : [],
     },
   };
 
@@ -70,10 +69,7 @@ class SecondPassphrase extends React.Component {
 
   changeHandler = (value, cb) => {
     this.setState({
-      secondPassphrase: {
-        value,
-        validity: [],
-      },
+      secondPassphrase: { value },
     }, () => {
       if (typeof cb === 'function') {
         cb();
@@ -118,7 +114,6 @@ class SecondPassphrase extends React.Component {
       return this.setState({
         secondPassphrase: {
           value: secondPassphrase.value,
-          validity,
         },
       });
     }


### PR DESCRIPTION
# What was the bug or feature?
Described in #670 

### How did I fix it?
Updated Send/SecondPassphrase page to use DropdownHolder for error messages.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Try to trigger errors by entering
- valid passphrase (but not the correct second passphrase)
- invalid passphrase

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
