### PR TITLE
Refactor the validation of Send/Overview step - Closes #671

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -98,6 +98,7 @@
   "Security reminder!": "Sicherheitserinnerung!",
   "Send": "Senden",
   "Send now": "Jetzt senden",
+  "Sending": "Sending...",
   "Send to this address": "Zu dieser Adresse senden",
   "Sender": "Absender",
   "Sent": "Gesendet",

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -98,6 +98,7 @@
   "Security reminder!": "Security reminder!",
   "Send": "Send",
   "Send now": "Send now",
+  "Sending": "Sending...",
   "Send to this address": "Send to this address",
   "Sender": "Sender",
   "Sent": "Sent",

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -44,8 +44,6 @@ export const transactionsLoaded = data => async (dispatch, getState) => {
  * @param {Function} errorCb - error callback
  */
 export const transactionAdded = (data, successCb, errorCb) => async (dispatch, getState) => {
-  dispatch(loadingStarted(actionTypes.transactionAdded));
-
   const activeToken = getState().settings.token.active;
   const account = getState().accounts.info[activeToken];
 
@@ -66,10 +64,8 @@ export const transactionAdded = (data, successCb, errorCb) => async (dispatch, g
       },
     });
 
-    dispatch(loadingFinished(actionTypes.transactionAdded));
     successCb({ txId: id });
   } catch (error) {
-    dispatch(loadingFinished(actionTypes.transactionAdded));
     errorCb(error);
   }
 };

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -150,7 +150,6 @@ describe('Action: Accounts', () => {
       const successCallback = jest.fn();
 
       const expectedActions = [
-        { type: actionTypes.loadingStarted, data: actionTypes.transactionsAdded },
         {
           type: actionTypes.pendingTransactionAdded,
           data: {
@@ -163,7 +162,6 @@ describe('Action: Accounts', () => {
             type: txConstants.send.type,
           },
         },
-        { type: actionTypes.loadingFinished, data: actionTypes.transactionsAdded },
       ];
 
       transactionsAPI.create.mockResolvedValueOnce('');
@@ -179,17 +177,11 @@ describe('Action: Accounts', () => {
       const successCallback = jest.fn();
       const errorCallback = jest.fn();
 
-      const expectedActions = [
-        { type: actionTypes.loadingStarted, data: actionTypes.transactionsAdded },
-        { type: actionTypes.loadingFinished, data: actionTypes.transactionsAdded },
-      ];
-
       transactionsAPI.create.mockResolvedValueOnce('');
       transactionsAPI.broadcast.mockRejectedValueOnce('Error');
 
       await store.dispatch(transactionAdded(inputData, successCallback, errorCallback));
 
-      expect(store.getActions()).toEqual(expectedActions);
       expect(errorCallback.mock.calls).toHaveLength(1);
     });
   });

--- a/src/components/send/overview/styles.js
+++ b/src/components/send/overview/styles.js
@@ -75,20 +75,6 @@ export default () => ({
     avatar: {
       marginBottom: 10,
     },
-    errorContainer: {
-      flexDirection: 'row',
-      justifyContent: 'center',
-      marginLeft: 20,
-      paddingRight: 20,
-      opacity: 0,
-    },
-    error: {
-      fontFamily: fonts.family.context,
-      fontSize: fonts.size.input,
-    },
-    errorIcon: {
-      marginRight: 5,
-    },
     visible: {
       opacity: 1,
     },
@@ -119,12 +105,6 @@ export default () => ({
     link: {
       color: colors.light.blue,
     },
-    error: {
-      color: colors.light.gray1,
-    },
-    errorIcon: {
-      color: colors.light.red,
-    },
   },
 
   [themes.dark]: {
@@ -148,12 +128,6 @@ export default () => ({
     },
     link: {
       color: colors.dark.blue,
-    },
-    error: {
-      color: colors.dark.gray4,
-    },
-    errorIcon: {
-      color: colors.dark.red,
     },
   },
 });


### PR DESCRIPTION
# What was the bug or feature?
Described in #671 

### How did I fix it?
- Update `Send/Overview` to use `DropdownHolder` for feedback 
- Removed `loadingStarted` and `loadingFinished` actions from `transactionAdded` because the loading indicator above is shown on top of the `DropdownAlert`.
- Updated title of the send button for busy state to provide a better solution for loading feedback. It will be more effective with #680.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Try to trigger an error during the `Send/Overview` step. 
- You can do it by using an invalid `BTC` or `LSK` address in the recipient step (because #662 is not merged yet) 


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
