### PR TITLE
Update Send screen to reset multistep after token change - Closes #683

### DIFF
--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -59,21 +59,30 @@ class Send extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkQuery(prevProps.navigation.getParam('query', {}));
+    // Reset the progress if active token has changed
+    if (prevProps.settings.token.active !== this.props.settings.token.active) {
+      this.resetMultiStep();
+    } else {
+      this.checkQuery(prevProps.navigation.getParam('query', {}));
+    }
   }
 
   componentWillUnmount() {
     this.subs.forEach(sub => sub.remove());
   }
 
+  resetMultiStep = (query = {}) => {
+    this.nav.reset(query);
+    this.props.navigation.setParams({
+      query: {},
+    });
+  }
+
   checkQuery = (prevQuery = {}) => {
     const query = this.props.navigation.getParam('query', {});
 
     if ((prevQuery !== query) && query && (Object.keys(query).length)) {
-      this.nav.reset(query);
-      this.props.navigation.setParams({
-        query: {},
-      });
+      this.resetMultiStep(query);
     }
   }
 


### PR DESCRIPTION
# What was the bug or feature?
Described in #683

### How did I fix it?
Added previous and current active token comparison to Send screen.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Switch the active token by using the token switcher when you're in the middle of Send steps.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
