### PR TITLE
Add styled theme to dynamic fee value - Closes #698

### DIFF
--- a/src/components/send/amount/dynamicFeeSelector/index.js
+++ b/src/components/send/amount/dynamicFeeSelector/index.js
@@ -28,7 +28,7 @@ const DynamicFeeSelector = ({
         <FormattedNumber
           type={B}
           tokenType={tokenType}
-          style={styles.value}
+          style={[styles.value, styles.theme.value]}
         >
           {fromRawLsk(value)}
         </FormattedNumber>


### PR DESCRIPTION
# What was the bug or feature?
Described in #698 

### How did I fix it?
Updated `value` component within the `dynamicFee` selector to colorize with respect to the selected theme.


## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Try to inspect the color of the calculated fee of BTC in Amount step, both for light and dark mode.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
