### PR TITLE
Handle unparsed BTC addresses - Closes #701

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -183,5 +183,6 @@
   "Here you will be able to manage your assets, in order to use them in the app.": "",
   "Primary": "",
   "You don't have any bookmarks. Start adding then through the sending process.": "Du hast noch keine Lesezeichen. Im Sendevorgang kannst du sie hinzufügen.",
-  "Error": "Fehler"
+  "Error": "Fehler",
+  "Unparsed Address": "Unparsed Address"
 }

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -182,5 +182,6 @@
   "Manage assets": "Manage assets",
   "Here you will be able to manage your assets, in order to use them in the app.": "Here you will be able to manage your assets, in order to use them in the app.",
   "Primary": "Primary",
-  "Error": "Error"
+  "Error": "Error",
+  "Unparsed Address": "Unparsed Address"
 }

--- a/src/components/transactions/item.js
+++ b/src/components/transactions/item.js
@@ -17,6 +17,12 @@ import getStyles from './styles';
 const txTypes = ['accountInitialization', 'setSecondPassphrase', 'registerDelegate', 'vote'];
 
 class Item extends React.Component {
+  componentDidMount() {
+    if (typeof this.props.tx.timestamp !== 'number') {
+      this.animation.play();
+    }
+  }
+
   showDetail = () => {
     const {
       navigate, tx, account, incognito,
@@ -28,10 +34,14 @@ class Item extends React.Component {
     });
   }
 
-  componentDidMount() {
-    if (typeof this.props.tx.timestamp !== 'number') {
-      this.animation.play();
+  getAddressText = (address) => {
+    const { t } = this.props;
+
+    if (address === 'Unparsed Address') {
+      return t('Unparsed Address');
     }
+
+    return stringShortener(address, 10, 3);
   }
 
   render() {
@@ -42,17 +52,17 @@ class Item extends React.Component {
 
     let direction = 'incoming';
     let address = tx.senderAddress;
-    let addressShortened = stringShortener(tx.senderAddress, 10, 3);
 
     if (account === tx.senderAddress && tx.type === 0) {
       direction = 'outgoing';
       address = tx.recipientAddress;
-      addressShortened = stringShortener(tx.recipientAddress, 10, 3);
     }
+
+    let addressText = this.getAddressText(address);
 
     const followedAccount = followedAccounts[activeToken].find(fa => fa.address === address);
     if (followedAccount) {
-      addressShortened = followedAccount.label;
+      addressText = followedAccount.label;
     }
 
     const amount = direction === 'incoming' ? fromRawLsk(tx.amount) : `-${fromRawLsk(tx.amount)}`;
@@ -79,7 +89,7 @@ class Item extends React.Component {
               (activeToken === 'LSK' &&
               (tx.type !== 0 || tx.recipientAddress === tx.senderAddress)) ?
               t(transactions[txTypes[tx.type]].title) :
-              addressShortened
+              addressText
             }
           </B>
           {

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -2,6 +2,8 @@ import bitcoin from 'bitcoinjs-lib';
 import config from '../../../../btc.config';
 import { extractAddress, getDerivedPathFromPassphrase } from './account';
 import { merge } from '../../helpers';
+import { validateAddress } from '../../validators';
+import { tokenMap } from '../../../constants/tokens';
 
 /**
  * Normalizes transaction data retrieved from Blockchain.info API
@@ -31,11 +33,13 @@ const normalizeTransactionsResponse = ({
 
   if (ownedInput) {
     data.senderAddress = address;
-    data.recipientAddress = tx.out[0].addr;
+    const extractedAddress = tx.out[0].addr;
+    data.recipientAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : '';
     data.amount = tx.out[0].value;
   } else {
     const output = tx.out.find(out => out.addr === address);
-    data.senderAddress = tx.inputs[0].prev_out.addr;
+    const extractedAddress = tx.inputs[0].prev_out.addr;
+    data.senderAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : '';
     data.recipientAddress = address;
     data.amount = output.value;
   }

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -34,12 +34,12 @@ const normalizeTransactionsResponse = ({
   if (ownedInput) {
     data.senderAddress = address;
     const extractedAddress = tx.out[0].addr;
-    data.recipientAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : '';
+    data.recipientAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : 'Unparsed Address';
     data.amount = tx.out[0].value;
   } else {
     const output = tx.out.find(out => out.addr === address);
     const extractedAddress = tx.inputs[0].prev_out.addr;
-    data.senderAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : '';
+    data.senderAddress = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : 'Unparsed Address';
     data.recipientAddress = address;
     data.amount = output.value;
   }

--- a/src/utilities/validators.js
+++ b/src/utilities/validators.js
@@ -23,6 +23,7 @@ export const validateAddress = (tokenType, address) => {
     // Reference: https://github.com/bitcoinjs/bitcoinjs-lib/issues/890
     case tokenMap.BTC.key:
       try {
+        bitcoin.address.fromBase58Check(address); // eliminates segwit addresses
         bitcoin.address.toOutputScript(address, btcConfig.network);
         return 0;
       } catch (e) {


### PR DESCRIPTION
# What was the bug or feature?
Described in #701 

### How did I fix it?
- Updated validateAddress helper for BTC to eliminate segwit addresses 
- Updated BTC normalizer to assign empty string for invalid addresses
- Updated transaction list item component to display Unparsed Address text correctly

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Login to the common test account, switch to the BTC.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
