### PR TITLE
Fix navigating to Other Accounts page from TXDetails - Closes #694

### DIFF
--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -103,18 +103,25 @@ class TransactionDetail extends React.Component {
 
   navigate = (address) => {
     const { navigation, account, activeToken } = this.props;
-    if (address !== account[activeToken].address) {
+
+    if (address !== account[activeToken].address && address !== 'Unparsed Address') {
       navigation.navigate('Wallet', { address });
     }
   }
 
-  getAccountLabel = (accountId) => {
-    const followedAccount = this.props.followedAccounts[this.props.activeToken]
-      .find(a => a.address === accountId);
+  getAccountLabel = (address) => {
+    const { t, followedAccounts, activeToken } = this.props;
+
+    if (address === 'Unparsed Address') {
+      return t('Unparsed Address');
+    }
+
+    const followedAccount = followedAccounts[activeToken].find(a => a.address === address);
     if (followedAccount) {
       return followedAccount.label;
     }
-    return accountId;
+
+    return address;
   };
 
   openExplorer = () => {


### PR DESCRIPTION
# What was the bug or feature?
Described in #694 

### How did I fix it?
Updated TXDetails page to handle the logic related to unparsed addresses.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Go to the TxDetail page with an unparsed address.
- Try to navigate to the wallet page of unparsed address.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
