### PR TITLE
Truncate the btc address in account summary - Closes #696

### DIFF
--- a/src/components/accountSummary/profile.js
+++ b/src/components/accountSummary/profile.js
@@ -8,7 +8,8 @@ import { P, H2 } from '../toolBox/typography';
 import withTheme from '../withTheme';
 import getStyles from './styles';
 import Icon from '../toolBox/icon';
-import { tokenMap } from '../../constants/tokens';
+import { tokenMap, tokenKeys } from '../../constants/tokens';
+import { stringShortener } from '../../utilities/helpers';
 import darkBig from '../../assets/images/balanceBlur/darkBig.png';
 import darkMedium from '../../assets/images/balanceBlur/darkMedium.png';
 import darkSmall from '../../assets/images/balanceBlur/darkSmall.png';
@@ -33,6 +34,8 @@ const Profile = ({
 }) => {
   const AView = Animated.View;
   let balanceSize = 'Small';
+  const address = token === tokenKeys[1] ?
+    stringShortener(account.address, 10, 10) : account.address;
 
   const normalizedBalance = fromRawLsk(account.balance);
   if (normalizedBalance.length > 6) balanceSize = 'Big';
@@ -74,7 +77,8 @@ const Profile = ({
           style={[styles.addressP, styles.theme.homeAddress]}
           iconColor={theme === 'dark' ? colors[theme].gray2 : colors[theme].gray5}
           containerStyle={styles.addressContainer}
-          value={account.address} icon={true} />
+          sharedValue={account.address}
+          value={address} icon={true} />
       </AView>
       <AView style={[styles.balance,
         {

--- a/src/components/accountSummary/profile.js
+++ b/src/components/accountSummary/profile.js
@@ -77,8 +77,8 @@ const Profile = ({
           style={[styles.addressP, styles.theme.homeAddress]}
           iconColor={theme === 'dark' ? colors[theme].gray2 : colors[theme].gray5}
           containerStyle={styles.addressContainer}
-          sharedValue={account.address}
-          value={address} icon={true} />
+          value={account.address}
+          title={address} icon={true} />
       </AView>
       <AView style={[styles.balance,
         {

--- a/src/components/accountSummary/wallet.js
+++ b/src/components/accountSummary/wallet.js
@@ -10,11 +10,12 @@ import Avatar from '../avatar';
 import Icon from '../toolBox/icon';
 import { fromRawLsk } from '../../utilities/conversions';
 import FormattedNumber from '../formattedNumber';
-import { tokenMap } from '../../constants/tokens';
+import { tokenMap, tokenKeys } from '../../constants/tokens';
 import Share from '../share';
 import { P, H2 } from '../toolBox/typography';
 import { IconButton } from '../toolBox/button';
 import easing from '../../utilities/easing';
+import { stringShortener } from '../../utilities/helpers';
 import withTheme from '../withTheme';
 import getStyles from './styles';
 import { colors, themes } from '../../constants/styleGuide';
@@ -103,6 +104,8 @@ class AccountSummary extends React.Component {
       styles, account, followedAccounts, activeToken,
       settings: { token }, theme, navigation, t,
     } = this.props;
+    const address = token.active === tokenKeys[1] ?
+      stringShortener(account.address, 10, 10) : account.address;
 
     const { interpolate } = this;
     const AView = Animated.View;
@@ -146,7 +149,9 @@ class AccountSummary extends React.Component {
             style={[styles.addressP, styles.theme.walletAddress]}
             iconColor={theme === 'dark' ? colors[theme].gray2 : colors[theme].gray1}
             containerStyle={styles.addressContainer}
-            value={account.address} icon={true} />
+            sharedValue={account.address}
+            value={address}
+            icon={true} />
         </AView>
         <AView style={[styles.balance, { opacity },
           {

--- a/src/components/accountSummary/wallet.js
+++ b/src/components/accountSummary/wallet.js
@@ -149,8 +149,8 @@ class AccountSummary extends React.Component {
             style={[styles.addressP, styles.theme.walletAddress]}
             iconColor={theme === 'dark' ? colors[theme].gray2 : colors[theme].gray1}
             containerStyle={styles.addressContainer}
-            sharedValue={account.address}
-            value={address}
+            value={account.address}
+            title={address}
             icon={true} />
         </AView>
         <AView style={[styles.balance, { opacity },

--- a/src/components/request/index.js
+++ b/src/components/request/index.js
@@ -92,6 +92,7 @@ class Request extends React.Component {
               <Share
                 type={TouchableWithoutFeedback}
                 value={url || address}
+                title={url || address}
               >
                 <View style={styles.shareContent}>
                   <QRCode

--- a/src/components/share/index.js
+++ b/src/components/share/index.js
@@ -6,7 +6,7 @@ import withTheme from '../withTheme';
 import getStyles from './styles';
 
 const Share = ({
-  styles, icon, value, style, type, children, containerStyle, iconColor, theme,
+  styles, icon, value, style, type, children, containerStyle, iconColor, theme, sharedValue,
 }) => {
   const Element = type || Text;
 
@@ -15,7 +15,7 @@ const Share = ({
       <Element
         style={style}
         onPress={() => ShareAPI.share({
-          message: value || children,
+          message: sharedValue || value || children,
           url: '',
         })}>{children || value}</Element>
       {
@@ -24,7 +24,7 @@ const Share = ({
                 name='share'
                 size={14}
                 onPress={() => ShareAPI.share({
-                  message: value || children,
+                  message: sharedValue || value || children,
                   url: '',
                 })}
                 color={iconColor || colors[theme].gray2} /> : null

--- a/src/components/share/index.js
+++ b/src/components/share/index.js
@@ -6,7 +6,7 @@ import withTheme from '../withTheme';
 import getStyles from './styles';
 
 const Share = ({
-  styles, icon, value, style, type, children, containerStyle, iconColor, theme, sharedValue,
+  styles, icon, value, style, type, children, containerStyle, iconColor, theme, title,
 }) => {
   const Element = type || Text;
 
@@ -15,16 +15,16 @@ const Share = ({
       <Element
         style={style}
         onPress={() => ShareAPI.share({
-          message: sharedValue || value || children,
+          message: value || children,
           url: '',
-        })}>{children || value}</Element>
+        })}>{children || title}</Element>
       {
         icon ? <Icon
                 style={styles.icon}
                 name='share'
                 size={14}
                 onPress={() => ShareAPI.share({
-                  message: sharedValue || value || children,
+                  message: value || children,
                   url: '',
                 })}
                 color={iconColor || colors[theme].gray2} /> : null

--- a/src/components/txDetail/index.js
+++ b/src/components/txDetail/index.js
@@ -223,6 +223,7 @@ class TransactionDetail extends React.Component {
             <Share
               type={B}
               value={tx.id}
+              title={tx.id}
               icon={true}
               style={[styles.value, styles.theme.value, styles.transactionId]}
             /> :


### PR DESCRIPTION
# What was the bug or feature?
It is described in #696.

## Type of change
- Enhancement (a non-breaking change which adds functionality)


### How to test it?
Btc addresses should be truncated in  account summary of the home and the wallet page

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
