### PR TITLE
Refactor launch protocol handler - Closes #593

### DIFF
--- a/src/components/signIn/index.js
+++ b/src/components/signIn/index.js
@@ -212,7 +212,7 @@ class SignIn extends React.Component {
     const linkedScreen = deepLinkMapper(url);
 
     if (linkedScreen) {
-      if (linkedScreen.params.activeToken) {
+      if (linkedScreen.params && linkedScreen.params.activeToken) {
         settingsUpdated({
           token: {
             list: settings.token.list,

--- a/src/components/signIn/index.js
+++ b/src/components/signIn/index.js
@@ -208,13 +208,23 @@ class SignIn extends React.Component {
   }
 
   navigateToDeepLink = (url) => {
+    const { navigation, settings, settingsUpdated } = this.props;
     const linkedScreen = deepLinkMapper(url);
 
     if (linkedScreen) {
-      this.props.navigation.navigate(linkedScreen.name, linkedScreen.params);
+      if (linkedScreen.params.activeToken) {
+        settingsUpdated({
+          token: {
+            list: settings.token.list,
+            active: linkedScreen.params.activeToken,
+          },
+        });
+      }
+
+      navigation.navigate(linkedScreen.name, linkedScreen.params);
     } else {
       // @TODO: Navigate to different page or display an error message for unmapped deep links.
-      this.props.navigation.navigate('Home');
+      navigation.navigate('Home');
     }
   }
 

--- a/src/utilities/deepLink.js
+++ b/src/utilities/deepLink.js
@@ -1,4 +1,5 @@
 import URL from 'url-parse';
+import { tokenMap } from '../constants/tokens';
 
 export default function deepLinkMapper(deepLinkURL) {
   if (!deepLinkURL) {
@@ -14,6 +15,7 @@ export default function deepLinkMapper(deepLinkURL) {
       return {
         name: 'Send',
         params: {
+          activeToken: tokenMap.LSK.key,
           query: {
             address: query.recipient,
             amount: query.amount,
@@ -25,13 +27,16 @@ export default function deepLinkMapper(deepLinkURL) {
     case 'request':
       return {
         name: 'Request',
-        params: {},
+        params: {
+          activeToken: tokenMap.LSK.key,
+        },
       };
 
     case 'transactions':
       return {
         name: 'TxDetail',
         params: {
+          activeToken: tokenMap.LSK.key,
           txId: query.id,
         },
       };

--- a/src/utilities/deepLink.js
+++ b/src/utilities/deepLink.js
@@ -27,9 +27,6 @@ export default function deepLinkMapper(deepLinkURL) {
     case 'request':
       return {
         name: 'Request',
-        params: {
-          activeToken: tokenMap.LSK.key,
-        },
       };
 
     case 'transactions':

--- a/src/utilities/deepLink.test.js
+++ b/src/utilities/deepLink.test.js
@@ -48,9 +48,6 @@ describe('Deep Link Handler', () => {
     const url = 'lisk://request';
     const expectedResult = {
       name: 'Request',
-      params: {
-        activeToken: tokenMap.LSK.key,
-      },
     };
 
     expect(deepLinkMapper(url)).toEqual(expectedResult);

--- a/src/utilities/deepLink.test.js
+++ b/src/utilities/deepLink.test.js
@@ -1,4 +1,5 @@
 import deepLinkMapper from './deepLink';
+import { tokenMap } from '../constants/tokens';
 
 describe('Deep Link Handler', () => {
   it('returns null if given url is falsy', () => {
@@ -14,6 +15,7 @@ describe('Deep Link Handler', () => {
     const expectedResult = {
       name: 'Send',
       params: {
+        activeToken: tokenMap.LSK.key,
         query: {
           address: '1L',
           amount: '1',
@@ -30,6 +32,7 @@ describe('Deep Link Handler', () => {
     const expectedResult = {
       name: 'Send',
       params: {
+        activeToken: tokenMap.LSK.key,
         query: {
           address: '1L',
           amount: '1',
@@ -45,7 +48,9 @@ describe('Deep Link Handler', () => {
     const url = 'lisk://request';
     const expectedResult = {
       name: 'Request',
-      params: {},
+      params: {
+        activeToken: tokenMap.LSK.key,
+      },
     };
 
     expect(deepLinkMapper(url)).toEqual(expectedResult);
@@ -56,6 +61,7 @@ describe('Deep Link Handler', () => {
     const expectedResult = {
       name: 'TxDetail',
       params: {
+        activeToken: tokenMap.LSK.key,
         txId: '1',
       },
     };


### PR DESCRIPTION
# What was the bug or feature?
Described in #593 

### How did I fix it?
- Created `withActiveToken` HOC to decrease code duplication.
- Updated `Send`, `Request` and `TxDetail` components to use `withActiveToken` HOC.
- Updated deep link handling logic in `Send` and `TxDetail` components

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
**Try to navigate to**
- [lisk://transactions?id=1620828138913920741](lisk://transactions?id=1620828138913920741)

- [lisk://wallet?recipient=14523184510698826853L&amount=5](lisk://wallet?recipient=14523184510698826853L&amount=5)
when your active token is in BTC.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
