### PR TITLE
Use new modal to confirm Sign Out action - Closes #735

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -185,5 +185,8 @@
   "Primary": "Primär",
   "You don’t have any bookmarks. Start adding then through the sending process.": "Du hast noch keine Lesezeichen. Im Sendevorgang kannst du sie hinzufügen.",
   "Error": "Fehler",
-  "Unparsed Address": "Unbekannte Adresse"
+  "Unparsed Address": "Unbekannte Adresse",
+  "Are you sure you want to sign out?": "Are you sure you want to sign out?",
+  "Signing out will disable bioAuth for the Lisk App.": "Signing out will disable {{sensorType}} for the Lisk App.",
+  "You can enable it after singing back in with your passphrase.": "You can enable it after singing back in with your passphrase."
 }

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -185,5 +185,8 @@
   "Primary": "Primary",
   "You don’t have any bookmarks. Start adding then through the sending process.": "You don’t have any bookmarks. Start adding then through the sending process.",
   "Error": "Error",
-  "Unparsed Address": "Unparsed Address"
+  "Unparsed Address": "Unparsed Address",
+  "Are you sure you want to sign out?": "Are you sure you want to sign out?",
+  "Signing out will disable bioAuth for the Lisk App.": "Signing out will disable {{sensorType}} for the Lisk App.",
+  "You can enable it after singing back in with your passphrase.": "You can enable it after singing back in with your passphrase."
 }

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -16,12 +16,14 @@ class Modal extends React.Component {
     contentStyle: {},
     Component: null,
     title: '',
+    modalCallback: () => true,
   }
 
   updateModal = (config) => {
     this.setState({
       title: config.title,
       Component: config.component || null,
+      modalCallback: config.callback,
     });
   }
 
@@ -36,10 +38,10 @@ class Modal extends React.Component {
   }
   render() {
     const {
-      styles, navigation,
+      styles,
     } = this.props;
     const { contentStyle, headerStyle } = this.state;
-    const { title, Component } = this.state;
+    const { title, Component, modalCallback } = this.state;
 
     return (<ModalBox position={'bottom'}
       style={styles.modal}
@@ -62,7 +64,7 @@ class Modal extends React.Component {
           </View>
           <ScrollView>
             <View style={[styles.contentContainer, contentStyle]}>
-              <Component navigation={navigation} close={this.closeModal} />
+              <Component modalCallback={modalCallback} close={this.closeModal} />
             </View>
           </ScrollView>
         </View>

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { ScrollView, View, Platform } from 'react-native';
 import connect from 'redux-connect-decorator';
 import { translate } from 'react-i18next';
-import { accountSignedOut as accountSignedOutAction } from '../../actions/accounts';
 import { H4, P } from '../toolBox/typography';
 import FingerprintOverlay from '../fingerprintOverlay';
 import ItemTitle from './itemTitle';
 import SignOutButton from './signOutButton';
+import SignOutModal from './signOutModal';
 import { colors, themes } from '../../constants/styleGuide';
 import withTheme from '../withTheme';
 import SwitchButton from '../toolBox/switchButton';
@@ -19,7 +19,6 @@ import getStyles from './styles';
 @connect(state => ({
   settings: state.settings,
 }), {
-  accountSignedOut: accountSignedOutAction,
   settingsUpdated: settingsUpdatedAction,
 })
 class Settings extends React.Component {
@@ -194,9 +193,7 @@ class Settings extends React.Component {
             <H4 style={[styles.subHeader, styles.theme.subHeader]}>{''}</H4>
             <View style={[styles.item, styles.theme.item]}>
               <SignOutButton
-                navigation={navigation}
-                signOut={this.props.accountSignedOut}
-                settings={settings}
+                onClick={() => navigation.navigate('Modal', { title: 'Signing out', component: SignOutModal })}
               />
             </View>
           </View>

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ScrollView, View, Platform } from 'react-native';
 import connect from 'redux-connect-decorator';
 import { translate } from 'react-i18next';
+import { NavigationActions } from 'react-navigation';
 import { H4, P } from '../toolBox/typography';
 import FingerprintOverlay from '../fingerprintOverlay';
 import ItemTitle from './itemTitle';
@@ -14,12 +15,15 @@ import { languageMap } from '../../constants/languages';
 import {
   settingsUpdated as settingsUpdatedAction,
 } from '../../actions/settings';
+import ModalHolder from '../../utilities/modal';
+import { accountSignedOut as accountSignedOutAction } from '../../actions/accounts';
 import getStyles from './styles';
 
 @connect(state => ({
   settings: state.settings,
 }), {
   settingsUpdated: settingsUpdatedAction,
+  accountSignedOut: accountSignedOutAction,
 })
 class Settings extends React.Component {
   state = {
@@ -49,6 +53,16 @@ class Settings extends React.Component {
     this.props.settingsUpdated({
       incognito: !this.props.settings.incognito,
     });
+  }
+
+  signOut = () => {
+    this.props.accountSignedOut();
+    this.props.navigation.dispatch(NavigationActions.reset({
+      index: 0,
+      actions: [
+        NavigationActions.navigate({ routeName: 'SignIn', params: { signOut: true } }),
+      ],
+    }));
   }
 
   render() {
@@ -193,7 +207,11 @@ class Settings extends React.Component {
             <H4 style={[styles.subHeader, styles.theme.subHeader]}>{''}</H4>
             <View style={[styles.item, styles.theme.item]}>
               <SignOutButton
-                onClick={() => navigation.navigate('Modal', { title: 'Signing out', component: SignOutModal })}
+                onClick={() => ModalHolder.open({
+                  title: 'Signing out',
+                  component: SignOutModal,
+                  callback: this.signOut,
+                })}
               />
             </View>
           </View>

--- a/src/components/settings/signOutButton/index.js
+++ b/src/components/settings/signOutButton/index.js
@@ -1,67 +1,22 @@
 import React from 'react';
-import { Alert } from 'react-native';
-import { NavigationActions } from 'react-navigation';
 import { translate } from 'react-i18next';
-import { removePassphraseFromKeyChain } from '../../../utilities/passphrase';
 import { IconButton } from '../../toolBox/button';
 import { colors } from '../../../constants/styleGuide';
 import withTheme from '../../withTheme';
 import getStyles from './styles';
 
-class SignOutButton extends React.Component {
-  onConfirm = () => {
-    // clean active account
-    this.props.signOut();
-    removePassphraseFromKeyChain();
-
-    // navigate to the signIn page
-    this.props.navigation
-      .dispatch(NavigationActions.reset({
-        index: 0,
-        actions: [NavigationActions.navigate({
-          routeName: 'SignIn',
-          params: {
-            signOut: true,
-          },
-        })],
-      }));
-  }
-
-  onClick = () => {
-    const { settings, t } = this.props;
-    let message;
-
-    if (settings.hasStoredPassphrase) {
-      message = t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`);
-    }
-
-    Alert.alert(t('Are you sure?'), message, [
-      {
-        text: t('Cancel'),
-        style: 'cancel',
-      },
-      {
-        text: t('Confirm'),
-        onPress: this.onConfirm,
-      },
-    ], { cancelable: false });
-  }
-
-  render() {
-    const { theme, styles, t } = this.props;
-
-    return (
-      <IconButton
-        icon='logout'
-        iconSize={18}
-        title={t('Sign out')}
-        color={colors[theme].blue}
-        onClick={this.onClick}
-        titleStyle={[styles.title, styles.theme.title]}
-        style={styles.button}
-      />
-    );
-  }
-}
+const SignOutButton = ({
+  onClick, theme, styles, t,
+}) => (
+  <IconButton
+    icon='logout'
+    iconSize={18}
+    title={t('Sign out')}
+    color={colors[theme].blue}
+    onClick={onClick}
+    titleStyle={[styles.title, styles.theme.title]}
+    style={styles.button}
+  />
+);
 
 export default withTheme(translate()(SignOutButton), getStyles());

--- a/src/components/settings/signOutModal/index.js
+++ b/src/components/settings/signOutModal/index.js
@@ -3,10 +3,12 @@ import { View } from 'react-native';
 import { translate } from 'react-i18next';
 import connect from 'redux-connect-decorator';
 import { NavigationActions } from 'react-navigation';
-import { A, P } from '../../toolBox/typography';
+import { A, Small } from '../../toolBox/typography';
 import { SecondaryButton } from '../../toolBox/button';
 import { accountSignedOut as accountSignedOutAction } from '../../../actions/accounts';
 import { removePassphraseFromKeyChain } from '../../../utilities/passphrase';
+import withTheme from '../../withTheme';
+import getStyles from './styles';
 
 @connect(state => ({
   settings: state.settings,
@@ -30,38 +32,42 @@ class SignOutModal extends React.Component {
   }
 
   render() {
-    const { settings, t } = this.props;
+    const { styles, settings, t } = this.props;
 
     let content = (
-      <P>{t('Are you sure?')}</P>
+      <Small style={[styles.text, styles.theme.text]}>
+        {t('Are you sure you want to sign out?')}
+      </Small>
     );
 
     if (settings.hasStoredPassphrase) {
       content = (
         <React.Fragment>
-          <P>
-            {t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`)}
-          </P>
+          <Small style={[styles.text, styles.theme.text]}>
+            {t('Signing out will disable bioAuth for the Lisk App.', { sensorType: settings.sensorType })}
+          </Small>
 
-          <P>
-            {t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`)}
-          </P>
+          <Small style={[styles.text, styles.theme.text]}>
+            {t('You can enable it after singing back in with your passphrase.')}
+          </Small>
         </React.Fragment>
       );
     }
 
     return (
-      <View>
-        <View>
-          {content}
-        </View>
+      <View style={styles.container}>
+        {content}
 
         <SecondaryButton
+          style={styles.actionButton}
           onClick={this.onConfirm}
           title={t('Confirm')}
         />
 
-        <A onPress={this.onCancel}>
+        <A
+          onPress={this.onCancel}
+          style={styles.theme.cancelButton}
+        >
           {t('Cancel')}
         </A>
       </View>
@@ -69,4 +75,4 @@ class SignOutModal extends React.Component {
   }
 }
 
-export default translate()(SignOutModal);
+export default withTheme(translate()(SignOutModal), getStyles());

--- a/src/components/settings/signOutModal/index.js
+++ b/src/components/settings/signOutModal/index.js
@@ -32,24 +32,38 @@ class SignOutModal extends React.Component {
   render() {
     const { settings, t } = this.props;
 
-    return (
-      <View>
-        <P>{t('Are you sure?')}</P>
+    let content = (
+      <P>{t('Are you sure?')}</P>
+    );
 
-        {settings.hasStoredPassphrase && (
+    if (settings.hasStoredPassphrase) {
+      content = (
+        <React.Fragment>
           <P>
             {t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`)}
           </P>
-        )}
 
-        <A onPress={this.onCancel}>
-          {t('Cancel')}
-        </A>
+          <P>
+            {t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`)}
+          </P>
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <View>
+        <View>
+          {content}
+        </View>
 
         <SecondaryButton
           onClick={this.onConfirm}
           title={t('Confirm')}
         />
+
+        <A onPress={this.onCancel}>
+          {t('Cancel')}
+        </A>
       </View>
     );
   }

--- a/src/components/settings/signOutModal/index.js
+++ b/src/components/settings/signOutModal/index.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View } from 'react-native';
+import { translate } from 'react-i18next';
+import connect from 'redux-connect-decorator';
+import { NavigationActions } from 'react-navigation';
+import { A, P } from '../../toolBox/typography';
+import { SecondaryButton } from '../../toolBox/button';
+import { accountSignedOut as accountSignedOutAction } from '../../../actions/accounts';
+import { removePassphraseFromKeyChain } from '../../../utilities/passphrase';
+
+@connect(state => ({
+  settings: state.settings,
+}), {
+  accountSignedOut: accountSignedOutAction,
+})
+class SignOutModal extends React.Component {
+  onConfirm = () => {
+    removePassphraseFromKeyChain();
+    this.props.accountSignedOut();
+    this.props.navigation.dispatch(NavigationActions.reset({
+      index: 0,
+      actions: [
+        NavigationActions.navigate({ routeName: 'Home', params: { signOut: true } }),
+      ],
+    }));
+  }
+
+  onCancel = () => {
+    this.props.close();
+  }
+
+  render() {
+    const { settings, t } = this.props;
+
+    return (
+      <View>
+        <P>{t('Are you sure?')}</P>
+
+        {settings.hasStoredPassphrase && (
+          <P>
+            {t(`You can sign back in using your passphrase and enable ${settings.sensorType} at any time.`)}
+          </P>
+        )}
+
+        <A onPress={this.onCancel}>
+          {t('Cancel')}
+        </A>
+
+        <SecondaryButton
+          onClick={this.onConfirm}
+          title={t('Confirm')}
+        />
+      </View>
+    );
+  }
+}
+
+export default translate()(SignOutModal);

--- a/src/components/settings/signOutModal/index.js
+++ b/src/components/settings/signOutModal/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { View } from 'react-native';
 import { translate } from 'react-i18next';
 import connect from 'redux-connect-decorator';
-import { NavigationActions } from 'react-navigation';
 import { A, Small } from '../../toolBox/typography';
 import { SecondaryButton } from '../../toolBox/button';
 import { accountSignedOut as accountSignedOutAction } from '../../../actions/accounts';
@@ -18,13 +17,8 @@ import getStyles from './styles';
 class SignOutModal extends React.Component {
   onConfirm = () => {
     removePassphraseFromKeyChain();
-    this.props.accountSignedOut();
-    this.props.navigation.dispatch(NavigationActions.reset({
-      index: 0,
-      actions: [
-        NavigationActions.navigate({ routeName: 'Home', params: { signOut: true } }),
-      ],
-    }));
+    this.props.modalCallback();
+    this.props.close();
   }
 
   onCancel = () => {

--- a/src/components/settings/signOutModal/styles.js
+++ b/src/components/settings/signOutModal/styles.js
@@ -1,0 +1,36 @@
+import { themes, colors, boxes } from '../../../constants/styleGuide';
+
+export default () => ({
+  common: {
+    container: {
+      alignItems: 'center',
+      paddingBottom: boxes.boxPadding,
+    },
+    text: {
+      textAlign: 'center',
+      lineHeight: 22,
+    },
+    actionButton: {
+      width: '100%',
+      margin: boxes.boxPadding,
+    },
+  },
+
+  [themes.light]: {
+    text: {
+      color: colors.light.gray2,
+    },
+    cancelButton: {
+      color: colors.light.gray2,
+    },
+  },
+
+  [themes.dark]: {
+    text: {
+      color: colors.dark.gray2,
+    },
+    cancelButton: {
+      color: colors.dark.gray2,
+    },
+  },
+});

--- a/src/utilities/modal.test.js
+++ b/src/utilities/modal.test.js
@@ -1,0 +1,27 @@
+import modalHolder from './modal';
+
+describe('modalHolder Handler', () => {
+  const modalMock = {
+    open: jest.fn(),
+    close: jest.fn(),
+  };
+  const update = jest.fn();
+  const config = {
+    title: 'title text',
+    component: 'modal',
+    callback: () => true,
+  };
+
+  it('modalHolder.close should call the close function of the passing modal ', () => {
+    modalHolder.initialize(modalMock, update);
+    modalHolder.close();
+    expect(modalMock.close).toBeCalled();
+  });
+
+  it('modalHolder.open should call the open function of the passing modal ', () => {
+    modalHolder.initialize(modalMock, update);
+    modalHolder.open(config);
+    expect(update).toBeCalledWith(config);
+    expect(modalMock.open).toBeCalled();
+  });
+});


### PR DESCRIPTION
# What was the bug or feature?
Described in #735

### How did I fix it?
- Simplified `SignOutButton` component and updated props passed to it in `Settings` page.
- Created `SignOutModal` with the new design and handles the confirmation task.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
- Login
- Go to Settings Screen
- Try to Sign Out


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
