### PR TITLE
Revisit BTC API utilities - Closes #684

### DIFF
--- a/btc.config.js
+++ b/btc.config.js
@@ -4,7 +4,7 @@ const isTestnet = process.env.network === 'testnet';
 
 export default {
   isTestnet,
-  url: isTestnet ? 'http://localhost:7201' : 'https://blockchain.info',
+  url: isTestnet ? 'https://ams1-bitcoin-test-001.ed148.net' : 'https://ams1-bitcoin-001.ed148.net',
   minerFeesURL: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
   network: isTestnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
   derivationPath: isTestnet ? "m/44'/1'/0'/0/0" : "m/44'/0'/0'/0/0",

--- a/btc.config.js
+++ b/btc.config.js
@@ -4,7 +4,7 @@ const isTestnet = process.env.network === 'testnet';
 
 export default {
   isTestnet,
-  url: isTestnet ? 'https://testnet.blockchain.info' : 'https://blockchain.info',
+  url: isTestnet ? 'http://localhost:7201' : 'https://blockchain.info',
   minerFeesURL: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
   network: isTestnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
   derivationPath: isTestnet ? "m/44'/1'/0'/0/0" : "m/44'/0'/0'/0/0",

--- a/src/utilities/api/btc/account.js
+++ b/src/utilities/api/btc/account.js
@@ -5,13 +5,12 @@ import config from '../../../../btc.config';
 
 export const getSummary = address => new Promise(async (resolve, reject) => {
   try {
-    const response = await fetch(`${config.url}/balance?active=${address}`, config.requestOptions);
+    const response = await fetch(`${config.url}/account/${address}`, config.requestOptions);
     const json = await response.json();
-
     if (response.ok) {
       resolve({
         address,
-        balance: json[address].final_balance,
+        balance: json.data.confirmed_balance,
         initialized: true,
       });
     } else {

--- a/src/utilities/api/btc/account.test.js
+++ b/src/utilities/api/btc/account.test.js
@@ -18,8 +18,8 @@ describe('api/btc/account', () => {
 
     it('resolves correctly', async () => {
       const response = {
-        [data.address]: {
-          final_balance: 1000,
+        data: {
+          confirmed_balance: 1000,
         },
       };
 
@@ -27,7 +27,7 @@ describe('api/btc/account', () => {
       const result = await getSummary(data.address);
       expect(result).toEqual({
         address: data.address,
-        balance: response[data.address].final_balance,
+        balance: response.data.confirmed_balance,
         initialized: true,
       });
     });

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -124,11 +124,11 @@ export const calculateTransactionFee = ({
  */
 export const getUnspentTransactionOutputs = address => new Promise(async (resolve, reject) => {
   try {
-    const response = await fetch(`${config.url}/unspent?active=${address}`);
+    const response = await fetch(`${config.url}/utxo/${address}`);
     const json = await response.json();
 
     if (response.ok) {
-      resolve(json.unspent_outputs);
+      resolve(json.data);
     } else {
       reject(json);
     }
@@ -186,7 +186,7 @@ export const create = ({
     // Add inputs from unspent txOuts
     // eslint-disable-next-line
     for (const tx of txOutsToConsume) {
-      txb.addInput(tx.tx_hash_big_endian, tx.tx_output_n);
+      txb.addInput(tx.tx_hash, tx.tx_pos);
     }
 
     // Output to Recipient

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -94,9 +94,7 @@ export const get = ({
 
       resolve({
         data,
-        meta: {
-          count: id ? 1 : json.data.length,
-        },
+        meta: json.meta || {},
       });
     } else {
       reject(json);

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -18,15 +18,15 @@ const normalizeTransactionsResponse = ({
   blockHeight,
 }) => list.map((tx) => {
   const data = {
-    id: tx.hash,
-    timestamp: Number(tx.time) * 1000,
+    id: tx.tx_hash,
+    timestamp: Number(tx.block.timestamp) * 1000,
     confirmations: blockHeight > 0 ? (blockHeight - tx.block_height) + 1 : tx.block_height,
     type: 0,
     data: '',
   };
 
   const totalInput = tx.inputs.reduce((total, t) => total + t.prev_out.value, 0);
-  const totalOutput = tx.out.reduce((total, t) => total + t.value, 0);
+  const totalOutput = tx.outputs.reduce((total, t) => total + t.satoshi, 0);
   data.fee = totalInput - totalOutput;
 
   const ownedInput = tx.inputs.find(i => i.prev_out.addr === address);
@@ -76,9 +76,9 @@ export const get = ({
     let response;
 
     if (id) {
-      response = await fetch(`${config.url}/rawtx/${id}`, config.requestOptions);
+      response = await fetch(`${config.url}/transaction/${id}`, config.requestOptions);
     } else {
-      response = await fetch(`${config.url}/rawaddr/${address}?limit=${limit}&offset=${offset}`, config.requestOptions);
+      response = await fetch(`${config.url}/transactions/${address}?limit=${limit}&offset=${offset}`, config.requestOptions);
     }
 
     const json = await response.json();
@@ -89,7 +89,7 @@ export const get = ({
       resolve({
         data: normalizeTransactionsResponse({
           address,
-          list: id ? [json] : json.txs,
+          list: id ? json.data : json.txs,
           blockHeight,
         }),
         meta: {

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -221,7 +221,7 @@ export const create = ({
 
 export const broadcast = transactionHex => new Promise(async (resolve, reject) => {
   try {
-    const response = await fetch(`${config.apiURL}/transaction`, merge(config.requestOptions, {
+    const response = await fetch(`${config.url}/transaction`, merge(config.requestOptions, {
       method: 'POST',
       body: JSON.stringify({ tx: transactionHex }),
     }));

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -20,7 +20,7 @@ const normalizeTransactionsResponse = ({
 }) => {
   const data = {
     id: tx.txid,
-    timestamp: Number(timestamp) * 1000,
+    timestamp: timestamp ? Number(timestamp) * 1000 : null,
     confirmations,
     type: 0,
     data: '',
@@ -49,7 +49,7 @@ const normalizeTransactionsResponse = ({
 export const get = ({
   id,
   address,
-  limit = 50,
+  limit = 20,
   offset = 0,
 }) => new Promise(async (resolve, reject) => {
   try {
@@ -68,10 +68,9 @@ export const get = ({
         address,
         list: id ? [json.data] : json.data,
       });
-
       resolve({
         data,
-        meta: json.meta || {},
+        meta: json.meta ? { count: json.meta.total } : {},
       });
     } else {
       reject(json);

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -88,7 +88,7 @@ export const get = ({
 
       const data = normalizeTransactionsResponse({
         address,
-        list: id ? [json] : json.data,
+        list: id ? [json.data] : json.data,
         blockHeight,
       });
 

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -221,20 +221,19 @@ export const create = ({
   }
 });
 
-export const broadcast = transaction => new Promise(async (resolve, reject) => {
+export const broadcast = transactionHex => new Promise(async (resolve, reject) => {
   try {
-    const body = new FormData();
-    body.append('tx', transaction);
-
-    const response = await fetch(`${config.url}/pushtx`, merge(config.requestOptions, {
+    const response = await fetch(`${config.apiURL}/transaction`, merge(config.requestOptions, {
       method: 'POST',
-      body,
+      body: JSON.stringify({ tx: transactionHex }),
     }));
 
+    const json = await response.json();
+
     if (response.ok) {
-      resolve(response.body);
+      resolve(json);
     } else {
-      reject(response.body);
+      reject(json);
     }
   } catch (error) {
     reject(error);

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -288,38 +288,39 @@ describe('api/btc/transactions', () => {
       });
     });
 
-    // @TODO: Fix before merge.
-    it.skip('resolves correctly for multiple transactions', async () => {
+    it('resolves correctly for multiple transactions', async () => {
       transactions.getLatestBlockHeight.mockResolvedValueOnce(0);
       fetchMock.once('*', response.getTransactions);
-      const result = await transactions.get({ address: address.mainnet });
+      const result = await transactions.get({ address: address.testnet });
       expect(result).toEqual({
         data: [
           {
-            id: 'a146763b49a6181e3fbc611def63af13ac2c08a0d97c80e64c93e8e083110aa9',
-            timestamp: 1548876059000,
-            confirmations: 560808,
-            fee: 1600,
-            senderAddress: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-            recipientAddress: 'Unparsed Address',
-            amount: 401723000,
+            id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+            timestamp: 1550570887000,
+            confirmations: 1478119,
+            fee: 1036,
+            senderAddress: 'Unparsed Address',
+            recipientAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+            amount: 1580000,
             type: 0,
             data: '',
           },
           {
-            id: 'e85812a1ce720f9bcda387465a7bd2c2bbfa8b62ce5220f2df1a3017cbda70e4',
-            timestamp: 1548345462000,
-            confirmations: 559919,
-            fee: 2260,
-            senderAddress: '1BrQvwTsDntfBAowYrqKq98MYY3dUNjnU3',
-            recipientAddress: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-            amount: 401724600,
+            id: 'd12774214858c1332b5c263700cb792ce5a814cb4596661c418644eff03cc007',
+            timestamp: 1550653562000,
+            confirmations: 1479229,
+            fee: 3626,
+            senderAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+            recipientAddress: 'Unparsed Address',
+            amount: 158,
             type: 0,
             data: '',
           },
         ],
         meta: {
           count: 2,
+          offset: 0,
+          total: 45,
         },
       });
     });

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -156,7 +156,6 @@ const response = {
   },
 };
 
-
 describe('api/btc/transactions', () => {
   describe('getLatestBlockHeight', () => {
     beforeEach(() => fetchMock.reset());
@@ -186,7 +185,8 @@ describe('api/btc/transactions', () => {
     });
 
     beforeEach(() => fetchMock.reset());
-    // remove the skip flags when the final api utility is implemented
+
+    // @TODO: Fix before merge.
     it.skip('resolves correctly for single transaction', async () => {
       const tx = response.getTransactions.txs[0];
       transactions.getLatestBlockHeight.mockResolvedValueOnce(600000);
@@ -213,6 +213,7 @@ describe('api/btc/transactions', () => {
       });
     });
 
+    // @TODO: Fix before merge.
     it.skip('resolves correctly for multiple transactions', async () => {
       transactions.getLatestBlockHeight.mockResolvedValueOnce(0);
       fetchMock.once('*', response.getTransactions);

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -186,8 +186,8 @@ describe('api/btc/transactions', () => {
     });
 
     beforeEach(() => fetchMock.reset());
-
-    it('resolves correctly for single transaction', async () => {
+    // remove the skip flags when the final api utility is implemented
+    it.skip('resolves correctly for single transaction', async () => {
       const tx = response.getTransactions.txs[0];
       transactions.getLatestBlockHeight.mockResolvedValueOnce(600000);
       fetchMock.once('*', tx);
@@ -213,7 +213,7 @@ describe('api/btc/transactions', () => {
       });
     });
 
-    it('resolves correctly for multiple transactions', async () => {
+    it.skip('resolves correctly for multiple transactions', async () => {
       transactions.getLatestBlockHeight.mockResolvedValueOnce(0);
       fetchMock.once('*', response.getTransactions);
       const result = await transactions.get({ address: address.mainnet });

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -221,18 +221,25 @@ const response = {
     },
   },
   getUnspentTransactionOutputs: {
-    unspent_outputs: [
+    data: [
       {
-        tx_hash: 'c156742387e44c7906091bc08d382951bfe1c9dc703856010e08ef803f90dafe',
-        tx_hash_big_endian: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
-        tx_index: 289209213,
-        tx_output_n: 0,
-        script: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
-        value: 1580000,
-        value_hex: '181be0',
-        confirmations: 1044,
+        tx_hash: '32c7d28320f9533f73e47f715b096020ae2c695c34ee7380401d03c96216f9ed',
+        tx_pos: 1,
+        height: 1488479,
+        value: 7327314,
+      },
+      {
+        tx_hash: '9daad153096f6907e611cba946a5681c727d7a1342388e12afd47de4efbc4002',
+        tx_pos: 1,
+        height: 1488489,
+        value: 871923,
       },
     ],
+    meta: {
+      total: 2,
+      offset: 0,
+      limit: 10,
+    },
   },
 };
 
@@ -350,11 +357,10 @@ describe('api/btc/transactions', () => {
   describe('getUnspentTransactionOutputs', () => {
     beforeEach(() => fetchMock.reset());
 
-    // @TODO: Fix before merge.
-    it.skip('resolves correctly', async () => {
+    it('resolves correctly', async () => {
       fetchMock.once('*', response.getUnspentTransactionOutputs);
-      const result = await transactions.getUnspentTransactionOutputs(address.mainnet);
-      expect(result).toEqual(response.getUnspentTransactionOutputs.unspent_outputs);
+      const result = await transactions.getUnspentTransactionOutputs(address.testnet);
+      expect(result).toEqual(response.getUnspentTransactionOutputs.data);
     });
 
     it('handles non-500 errors', async () => {
@@ -385,7 +391,7 @@ describe('api/btc/transactions', () => {
 
       transactions.getUnspentTransactionOutputs = jest.fn();
       transactions.getUnspentTransactionOutputs
-        .mockResolvedValue(response.getUnspentTransactionOutputs.unspent_outputs);
+        .mockResolvedValue(response.getUnspentTransactionOutputs.data);
     });
 
     it('throws error for insufficient balance', async () => {
@@ -401,8 +407,7 @@ describe('api/btc/transactions', () => {
       }
     });
 
-    // @TODO: Fix before merge.
-    it.skip('creates a valid transaction', async () => {
+    it('creates a valid transaction', async () => {
       const tx = await transactions.create({
         passphrase,
         recipientAddress: address.testnetRecipient,

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -297,9 +297,7 @@ describe('api/btc/transactions', () => {
           },
         ],
         meta: {
-          count: 2,
-          offset: 0,
-          total: 45,
+          count: 45,
         },
       });
     });

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -244,37 +244,10 @@ const response = {
 };
 
 describe('api/btc/transactions', () => {
-  describe('getLatestBlockHeight', () => {
-    beforeEach(() => fetchMock.reset());
-
-    it('resolves correctly', async () => {
-      fetchMock.once('*', { height: 1 });
-      const result = await transactions.getLatestBlockHeight();
-      expect(result).toEqual(1);
-    });
-
-    it('handles non-500 errors and resolves 0', async () => {
-      fetchMock.once('*', { status: 400, body: { message: 'error' } });
-      const result = await transactions.getLatestBlockHeight();
-      expect(result).toEqual(0);
-    });
-
-    it('handles errors and resolves 0', async () => {
-      fetchMock.once('*', { throws: new TypeError('Failed to fetch') });
-      const result = await transactions.getLatestBlockHeight();
-      expect(result).toEqual(0);
-    });
-  });
-
   describe('get', () => {
-    beforeAll(() => {
-      transactions.getLatestBlockHeight = jest.fn();
-    });
-
     beforeEach(() => fetchMock.reset());
 
     it('resolves correctly for single transaction', async () => {
-      transactions.getLatestBlockHeight.mockResolvedValueOnce(600000);
       fetchMock.once('*', response.getTransaction);
       const result = await transactions.get({ address: address.testnet, id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1' });
       expect(result).toEqual({
@@ -282,7 +255,7 @@ describe('api/btc/transactions', () => {
           {
             id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
             timestamp: 1550570887000,
-            confirmations: NaN, // @TODO: fix this after bitcoin-bridge implements confirmations
+            confirmations: 10611,
             fee: 1036,
             recipientAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
             senderAddress: 'Unparsed Address',
@@ -296,7 +269,6 @@ describe('api/btc/transactions', () => {
     });
 
     it('resolves correctly for multiple transactions', async () => {
-      transactions.getLatestBlockHeight.mockResolvedValueOnce(0);
       fetchMock.once('*', response.getTransactions);
       const result = await transactions.get({ address: address.testnet });
       expect(result).toEqual({
@@ -304,7 +276,7 @@ describe('api/btc/transactions', () => {
           {
             id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
             timestamp: 1550570887000,
-            confirmations: 1478119,
+            confirmations: 10609,
             fee: 1036,
             senderAddress: 'Unparsed Address',
             recipientAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
@@ -315,7 +287,7 @@ describe('api/btc/transactions', () => {
           {
             id: 'd12774214858c1332b5c263700cb792ce5a814cb4596661c418644eff03cc007',
             timestamp: 1550653562000,
-            confirmations: 1479229,
+            confirmations: 9499,
             fee: 3626,
             senderAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
             recipientAddress: 'Unparsed Address',

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -12,133 +12,213 @@ const address = {
 };
 
 const response = {
-  getTransactions: {
-    hash160: '4f6a9f245359d3b3441fcd22117c78466039caba',
-    address: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-    n_tx: 2,
-    total_received: 401724600,
-    total_sent: 401724600,
-    final_balance: 0,
-    txs: [
-      {
-        ver: 1,
+  getTransaction: {
+    data: {
+      tx_raw: '02000000010701c2516a8374c0ef5e04154868949951115c33b99a127ca7948ec038b0b486010000006a47304402206ef553185610d6fb57ab7e841b64094c93443dd017a90c62d4526f3c6675b52e02204a508443ec4bad8c62aaf34a6605a1795dd11b96e3c90d0b30f79651e34f440701210288a7e893e8fa0c0ff0c83c4137ae331f0216a93cb3eecb79a5274aa0964d67e6ffffffff02e01b1800000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac90400c00000000001976a914c57eaf552742752e4d3887a7a341714df670667388ac00000000',
+      tx: {
+        txid: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+        version: 2,
+        locktime: 0,
         inputs: [
           {
+            txid: '86b4b038c08e94a77c129ab9335c11519994684815045eefc074836a51c20107',
+            n: 1,
+            script: '304402206ef553185610d6fb57ab7e841b64094c93443dd017a90c62d4526f3c6675b52e02204a508443ec4bad8c62aaf34a6605a1795dd11b96e3c90d0b30f79651e34f440701 0288a7e893e8fa0c0ff0c83c4137ae331f0216a93cb3eecb79a5274aa0964d67e6',
             sequence: 4294967295,
-            witness: '',
-            prev_out: {
-              spent: true,
-              spending_outpoints: [
-                {
-                  tx_index: 411031256,
-                  n: 0,
-                },
-              ],
-              tx_index: 409136088,
-              type: 0,
-              addr: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-              value: 401724600,
+            txDetail: {
+              satoshi: 2383996,
+              value: '0.02383996',
               n: 1,
-              script: '76a9144f6a9f245359d3b3441fcd22117c78466039caba88ac',
+              scriptPubKey: {
+                asm: 'OP_DUP OP_HASH160 c57eaf552742752e4d3887a7a341714df6706673 OP_EQUALVERIFY OP_CHECKSIG',
+                hex: '76a914c57eaf552742752e4d3887a7a341714df670667388ac',
+                addresses: [
+                  'myXDB4jvDaLqStdeSBKJwhVbVHWuynQiY5',
+                ],
+              },
             },
-            script: '473044022078ca6d574cb3272fa7dfb28fd31a1acd9099dd521c1d4e7accb2086f60ad484202207b4131d72f6caf3a2c7758771b03e1b071cf0d8ee43f719bae2673ca79a2b7d701210305dbc31667a16d565c6f37da58ec37230f241eacd5950137df7b5a08996e6730',
           },
         ],
-        weight: 756,
-        block_height: 560808,
-        relayed_by: '0.0.0.0',
-        out: [
+        outputs: [
           {
-            spent: false,
-            tx_index: 411031256,
-            type: 0,
-            addr: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-            value: 401723000,
+            satoshi: 1580000,
+            value: '0.01580000',
             n: 0,
-            script: 'a91463f59fff9f9f13075e445d1ee6f864d0f375f91f87',
+            scriptPubKey: {
+              asm: 'OP_DUP OP_HASH160 f201b8d17483229dc8198e6baf05ddff94213238 OP_EQUALVERIFY OP_CHECKSIG',
+              hex: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+              addresses: [
+                'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+              ],
+            },
+          },
+          {
+            satoshi: 802960,
+            value: '0.00802960',
+            n: 1,
+            scriptPubKey: {
+              asm: 'OP_DUP OP_HASH160 c57eaf552742752e4d3887a7a341714df6706673 OP_EQUALVERIFY OP_CHECKSIG',
+              hex: '76a914c57eaf552742752e4d3887a7a341714df670667388ac',
+              addresses: [
+                'myXDB4jvDaLqStdeSBKJwhVbVHWuynQiY5',
+              ],
+            },
           },
         ],
-        lock_time: 0,
-        result: 0,
-        size: 189,
-        block_index: 1748075,
-        time: 1548876059,
-        tx_index: 411031256,
-        vin_sz: 1,
-        hash: 'a146763b49a6181e3fbc611def63af13ac2c08a0d97c80e64c93e8e083110aa9',
-        vout_sz: 1,
+      },
+      timestamp: 1550570887,
+      confirmations: 10611,
+      feeSatoshi: 1036,
+      inputTotalSatoshi: 2383996,
+      outputTotalSatoshi: 2382960,
+    },
+  },
+  getTransactions: {
+    data: [
+      {
+        tx_raw: '02000000010701c2516a8374c0ef5e04154868949951115c33b99a127ca7948ec038b0b486010000006a47304402206ef553185610d6fb57ab7e841b64094c93443dd017a90c62d4526f3c6675b52e02204a508443ec4bad8c62aaf34a6605a1795dd11b96e3c90d0b30f79651e34f440701210288a7e893e8fa0c0ff0c83c4137ae331f0216a93cb3eecb79a5274aa0964d67e6ffffffff02e01b1800000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac90400c00000000001976a914c57eaf552742752e4d3887a7a341714df670667388ac00000000',
+        tx: {
+          txid: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+          version: 2,
+          locktime: 0,
+          inputs: [
+            {
+              txid: '86b4b038c08e94a77c129ab9335c11519994684815045eefc074836a51c20107',
+              n: 1,
+              script: '304402206ef553185610d6fb57ab7e841b64094c93443dd017a90c62d4526f3c6675b52e02204a508443ec4bad8c62aaf34a6605a1795dd11b96e3c90d0b30f79651e34f440701 0288a7e893e8fa0c0ff0c83c4137ae331f0216a93cb3eecb79a5274aa0964d67e6',
+              sequence: 4294967295,
+              txDetail: {
+                satoshi: 2383996,
+                value: '0.02383996',
+                n: 1,
+                scriptPubKey: {
+                  asm: 'OP_DUP OP_HASH160 c57eaf552742752e4d3887a7a341714df6706673 OP_EQUALVERIFY OP_CHECKSIG',
+                  hex: '76a914c57eaf552742752e4d3887a7a341714df670667388ac',
+                  addresses: [
+                    'myXDB4jvDaLqStdeSBKJwhVbVHWuynQiY5',
+                  ],
+                },
+              },
+            },
+          ],
+          outputs: [
+            {
+              satoshi: 1580000,
+              value: '0.01580000',
+              n: 0,
+              scriptPubKey: {
+                asm: 'OP_DUP OP_HASH160 f201b8d17483229dc8198e6baf05ddff94213238 OP_EQUALVERIFY OP_CHECKSIG',
+                hex: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+                addresses: [
+                  'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+                ],
+              },
+            },
+            {
+              satoshi: 802960,
+              value: '0.00802960',
+              n: 1,
+              scriptPubKey: {
+                asm: 'OP_DUP OP_HASH160 c57eaf552742752e4d3887a7a341714df6706673 OP_EQUALVERIFY OP_CHECKSIG',
+                hex: '76a914c57eaf552742752e4d3887a7a341714df670667388ac',
+                addresses: [
+                  'myXDB4jvDaLqStdeSBKJwhVbVHWuynQiY5',
+                ],
+              },
+            },
+          ],
+        },
+        timestamp: 1550570887,
+        confirmations: 10609,
+        height: 1478119,
+        block: {
+          version: 536870912,
+          prev_block_hash: '00000000000007a4def048fff841cb1826e6fadfc46992b2eed4d1b4ee56a9d5',
+          merkle_root: '904f8d2a7b48493deb0265a18199ed56f6ab04301be9c9bbda728a30641e79c8',
+          timestamp: 1550570887,
+          bits: 437239872,
+          nonce: 237766340,
+          block_height: 1478119,
+        },
+        feeSatoshi: 1036,
+        inputTotalSatoshi: 2383996,
+        outputTotalSatoshi: 2382960,
       },
       {
-        ver: 1,
-        inputs: [
-          {
-            sequence: 4294967293,
-            witness: '',
-            prev_out: {
-              spent: true,
-              spending_outpoints: [
-                {
-                  tx_index: 409136088,
-                  n: 0,
-                },
-              ],
-              tx_index: 409075879,
-              type: 0,
-              addr: '1BrQvwTsDntfBAowYrqKq98MYY3dUNjnU3',
-              value: 774865158,
-              n: 1,
-              script: '76a91477099d9f2157a80c403dcb4c87f20b29f04506f088ac',
-            },
-            script: '483045022100e06322de8e7fc608084a2b7f83da88b6474cd4b7ef52b8cf53258adc7cb8814b022032dba7068cab1cc7bbb561ca17c61335642627d98bae7798283f75920fe03204012102a9059f4e87767f7e0ea5efceb33fc4cb8f6139a8c251bf8798e873d96105bef2',
-          },
-        ],
-        weight: 904,
-        block_height: 559919,
-        relayed_by: '0.0.0.0',
-        out: [
-          {
-            spent: true,
-            spending_outpoints: [
-              {
-                tx_index: 411616078,
-                n: 1,
-              },
-            ],
-            tx_index: 409136088,
-            type: 0,
-            addr: '14k18ngzkYcPnriyTNMaSnNgQBCRsKunYM',
-            value: 373138298,
-            n: 0,
-            script: '76a914290a6033f096917b3609621b9407aed043d01c1e88ac',
-          },
-          {
-            spent: true,
-            spending_outpoints: [
-              {
-                tx_index: 411031256,
+        tx_raw: '0200000001c156742387e44c7906091bc08d382951bfe1c9dc703856010e08ef803f90dafe000000006b483045022100d1dde0fe78b5e20d570348eca954336ccdfd8b25cb150203977e690b3dbc71eb02205f45fde27ded53dec38ca96530722f11bd4c0da96acd698e3d826395a57cfcac012102cd9e67acba4950837bb773b6d05f54ba0594aa4863b9dcb0dfe0bb94d14c56c2ffffffff029e000000000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac180d1800000000001976a914f201b8d17483229dc8198e6baf05ddff9421323888ac00000000',
+        tx: {
+          txid: 'd12774214858c1332b5c263700cb792ce5a814cb4596661c418644eff03cc007',
+          version: 2,
+          locktime: 0,
+          inputs: [
+            {
+              txid: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+              n: 0,
+              script: '3045022100d1dde0fe78b5e20d570348eca954336ccdfd8b25cb150203977e690b3dbc71eb02205f45fde27ded53dec38ca96530722f11bd4c0da96acd698e3d826395a57cfcac01 02cd9e67acba4950837bb773b6d05f54ba0594aa4863b9dcb0dfe0bb94d14c56c2',
+              sequence: 4294967295,
+              txDetail: {
+                satoshi: 1580000,
+                value: '0.01580000',
                 n: 0,
+                scriptPubKey: {
+                  asm: 'OP_DUP OP_HASH160 f201b8d17483229dc8198e6baf05ddff94213238 OP_EQUALVERIFY OP_CHECKSIG',
+                  hex: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+                  addresses: [
+                    'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+                  ],
+                },
               },
-            ],
-            tx_index: 409136088,
-            type: 0,
-            addr: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-            value: 401724600,
-            n: 1,
-            script: '76a9144f6a9f245359d3b3441fcd22117c78466039caba88ac',
-          },
-        ],
-        lock_time: 559918,
-        result: -401724600,
-        size: 226,
-        rbf: true,
-        block_index: 1745627,
-        time: 1548345462,
-        tx_index: 409136088,
-        vin_sz: 1,
-        hash: 'e85812a1ce720f9bcda387465a7bd2c2bbfa8b62ce5220f2df1a3017cbda70e4',
-        vout_sz: 2,
+            },
+          ],
+          outputs: [
+            {
+              satoshi: 158,
+              value: '0.00000158',
+              n: 0,
+              scriptPubKey: {
+                asm: 'OP_DUP OP_HASH160 f201b8d17483229dc8198e6baf05ddff94213238 OP_EQUALVERIFY OP_CHECKSIG',
+                hex: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+                addresses: [
+                  'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+                ],
+              },
+            },
+            {
+              satoshi: 1576216,
+              value: '0.01576216',
+              n: 1,
+              scriptPubKey: {
+                asm: 'OP_DUP OP_HASH160 f201b8d17483229dc8198e6baf05ddff94213238 OP_EQUALVERIFY OP_CHECKSIG',
+                hex: '76a914f201b8d17483229dc8198e6baf05ddff9421323888ac',
+                addresses: [
+                  'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+                ],
+              },
+            },
+          ],
+        },
+        timestamp: 1550653562,
+        confirmations: 9499,
+        height: 1479229,
+        block: {
+          version: 536870912,
+          prev_block_hash: '0000000000000abed1641f96f7b32b4829b2baf259ded5acc4c0dd88ab1dd3d3',
+          merkle_root: '0284ed79690dcaac5bed6adde65fe865aa6c4bd8553039219e76d52b96b531a0',
+          timestamp: 1550653562,
+          bits: 437239872,
+          nonce: 1618048865,
+          block_height: 1479229,
+        },
+        feeSatoshi: 3626,
+        inputTotalSatoshi: 1580000,
+        outputTotalSatoshi: 1576374,
       },
     ],
+    meta: {
+      count: 2,
+      offset: 0,
+      total: 45,
+    },
   },
   getUnspentTransactionOutputs: {
     unspent_outputs: [
@@ -186,30 +266,25 @@ describe('api/btc/transactions', () => {
 
     beforeEach(() => fetchMock.reset());
 
-    // @TODO: Fix before merge.
-    it.skip('resolves correctly for single transaction', async () => {
-      const tx = response.getTransactions.txs[0];
+    it('resolves correctly for single transaction', async () => {
       transactions.getLatestBlockHeight.mockResolvedValueOnce(600000);
-      fetchMock.once('*', tx);
-      const id = tx.hash;
-      const result = await transactions.get({ address: address.mainnet, id });
+      fetchMock.once('*', response.getTransaction);
+      const result = await transactions.get({ address: address.testnet, id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1' });
       expect(result).toEqual({
         data: [
           {
-            id: 'a146763b49a6181e3fbc611def63af13ac2c08a0d97c80e64c93e8e083110aa9',
-            timestamp: 1548876059000,
-            confirmations: (600000 - 560808) + 1,
-            fee: 1600,
-            senderAddress: '18Ev7MgYe9qPrXy6CKSvphhoeyTg6m8Nve',
-            recipientAddress: 'Unparsed Address',
-            amount: 401723000,
+            id: 'feda903f80ef080e01563870dcc9e1bf5129388dc01b0906794ce487237456c1',
+            timestamp: 1550570887000,
+            confirmations: NaN, // @TODO: fix this after bitcoin-bridge implements confirmations
+            fee: 1036,
+            recipientAddress: 'n3aZt7uZhnBeC9quq6btKyC8qXvskEiE1B',
+            senderAddress: 'Unparsed Address',
+            amount: 1580000,
             data: '',
             type: 0,
           },
         ],
-        meta: {
-          count: 1,
-        },
+        meta: {},
       });
     });
 

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -274,7 +274,8 @@ describe('api/btc/transactions', () => {
   describe('getUnspentTransactionOutputs', () => {
     beforeEach(() => fetchMock.reset());
 
-    it('resolves correctly', async () => {
+    // @TODO: Fix before merge.
+    it.skip('resolves correctly', async () => {
       fetchMock.once('*', response.getUnspentTransactionOutputs);
       const result = await transactions.getUnspentTransactionOutputs(address.mainnet);
       expect(result).toEqual(response.getUnspentTransactionOutputs.unspent_outputs);
@@ -324,7 +325,8 @@ describe('api/btc/transactions', () => {
       }
     });
 
-    it('creates a valid transaction', async () => {
+    // @TODO: Fix before merge.
+    it.skip('creates a valid transaction', async () => {
       const tx = await transactions.create({
         passphrase,
         recipientAddress: address.testnetRecipient,

--- a/src/utilities/api/btc/transactions.test.js
+++ b/src/utilities/api/btc/transactions.test.js
@@ -341,14 +341,14 @@ describe('api/btc/transactions', () => {
     beforeEach(() => fetchMock.reset());
 
     it('resolves correctly', async () => {
-      const successResponse = 'Transaction Submitted';
+      const successResponse = { message: 'Transaction Submitted' };
       fetchMock.once('*', successResponse);
       const result = await transactions.broadcast(txHex);
       expect(result).toEqual(successResponse);
     });
 
     it('handles non-500 errors', async () => {
-      const errorResponse = 'Transaction already exists';
+      const errorResponse = { message: 'Transaction already exists' };
       fetchMock.once('*', { status: 400, body: errorResponse });
 
       try {


### PR DESCRIPTION
# What was the bug or feature?
It is described in #684.

### How did I fix it?
- Updated `btc` api utilities to work with the internal API.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Use BTC related parts of the app to
- view tx list
- view tx details
- send a transaction

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
