### PR TITLE
Update new transaction filtering logic in blockUpdated action - Closes #775

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -178,7 +178,7 @@ export const blockUpdated = () => async (dispatch, getState) => {
     });
 
     const newTransactions = lastTx ?
-      response.data.filter(tx => tx.confirmations <= lastTx.confirmations) :
+      response.data.filter(tx => tx.confirmations === 0 || tx.timestamp > lastTx.timestamp) :
       response.data;
 
     if (newTransactions.length) {

--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -169,7 +169,7 @@ export const blockUpdated = () => async (dispatch, getState) => {
   const activeToken = getState().settings.token.active;
   const { address } = getState().accounts.info[activeToken];
   const { confirmed } = getState().transactions;
-  const lastTx = confirmed.length > 0 ? confirmed[0] : { timestamp: 0 };
+  const lastTx = confirmed.length > 0 ? confirmed[0] : null;
 
   try {
     const response = await transactionsAPI.get(activeToken, {
@@ -177,7 +177,9 @@ export const blockUpdated = () => async (dispatch, getState) => {
       offset: 0,
     });
 
-    const newTransactions = response.data.filter(tx => tx.timestamp > lastTx.timestamp);
+    const newTransactions = lastTx ?
+      response.data.filter(tx => tx.confirmations <= lastTx.confirmations) :
+      response.data;
 
     if (newTransactions.length) {
       dispatch({

--- a/src/actions/accounts.test.js
+++ b/src/actions/accounts.test.js
@@ -176,6 +176,41 @@ describe('Action: Accounts', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
+    it('should update user and transactions when store is not empty', async () => {
+      store = mockStore({
+        accounts,
+        transactions: {
+          confirmed: [{
+            timestamp: 0,
+          }],
+        },
+        settings,
+      });
+
+      const expectedActions = [
+        {
+          type: actionTypes.transactionsUpdated,
+          data: {
+            confirmed: data.transactions.data,
+            count: data.transactions.meta.count,
+          },
+        },
+        {
+          type: actionTypes.accountUpdated,
+          data: {
+            account: data.account,
+            activeToken: data.activeToken,
+          },
+        },
+      ];
+
+      accountAPI.getSummary.mockResolvedValueOnce(data.account);
+      transactionsAPI.get.mockResolvedValueOnce(data.transactions);
+
+      await store.dispatch(blockUpdated());
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
     it('should not update if there is no new transaction', async () => {
       transactionsAPI.get.mockResolvedValueOnce({ data: [] });
       await store.dispatch(blockUpdated());

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -70,7 +70,10 @@ export const transactionAdded = (data, successCb, errorCb) => async (dispatch, g
       successCb({ txId: id });
     } else {
       await transactionsAPI.broadcast(activeToken, tx);
-      dispatch(transactionsLoaded());
+
+      dispatch(transactionsReset());
+      dispatch(transactionsLoaded({ address: account.address }));
+
       successCb();
     }
   } catch (error) {

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -173,6 +173,44 @@ describe('Action: Accounts', () => {
       expect(successCallback.mock.calls).toHaveLength(1);
     });
 
+    it('should handle flow for non-LSK tokens', async () => {
+      const successCallback = jest.fn();
+
+      settings.token.active = 'BTC';
+      store = mockStore({
+        accounts: {
+          info: {
+            LSK: account,
+            BTC: {},
+          },
+        },
+        transactions: { confirmed: [], pending: [] },
+        settings,
+      });
+
+      const expectedActions = [
+        {
+          type: actionTypes.transactionsReset,
+        },
+        {
+          type: 'LOADING_STARTED',
+          data: actionTypes.transactionsLoaded,
+        },
+        {
+          type: 'LOADING_FINISHED',
+          data: actionTypes.transactionsLoaded,
+        },
+      ];
+
+      transactionsAPI.create.mockResolvedValueOnce('');
+      transactionsAPI.broadcast.mockResolvedValueOnce(transactions.data[0]);
+
+      await store.dispatch(transactionAdded(inputData, successCallback));
+
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(successCallback.mock.calls).toHaveLength(1);
+    });
+
     it('should go to error flow', async () => {
       const successCallback = jest.fn();
       const errorCallback = jest.fn();

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -21,7 +21,7 @@ const normalizeTransactionsResponse = ({
   const data = {
     id: tx.txid,
     timestamp: timestamp ? Number(timestamp) * 1000 : null,
-    confirmations,
+    confirmations: confirmations || 0,
     type: 0,
     data: '',
   };
@@ -68,6 +68,7 @@ export const get = ({
         address,
         list: id ? [json.data] : json.data,
       });
+
       resolve({
         data,
         meta: json.meta ? { count: json.meta.total } : {},

--- a/src/utilities/api/btc/transactions.js
+++ b/src/utilities/api/btc/transactions.js
@@ -10,7 +10,6 @@ import { tokenMap } from '../../../constants/tokens';
  * @param {Object} data
  * @param {String} data.address Base address to use for formatting transactions
  * @param {Array} data.list Transaction list retrieved from API
- * @param {Number} data.blockHeight Latest block height for calculating confirmation count
  */
 const normalizeTransactionsResponse = ({
   address,


### PR DESCRIPTION
# What was the bug or feature?
Described in #775 

### How did I fix it?
Updated blockUpdated action with a more accurate newTransaction filtering logic.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
- Broadcast an LSK / BTC transaction and re-fetch the tx list.
- Check and verify the accuracy of the position of the unconfirmed transaction.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
