### PR TITLE
Use exact version for react-native-camera - Closes #784

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12056,10 +12056,11 @@
       "version": "github:yasharAyari/react-native-blur-overlay#38e69384d644608a62450d5fabe94541fe272dfb"
     },
     "react-native-camera": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-1.13.1.tgz",
-      "integrity": "sha512-wYjMi06ygYIiHRM4dSCH914xFUay7Wplx0bAej4iBkZeh54M4AxJDcF4vVZ5vdkpuAg8zvof3l+L1VhcKziMgw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-1.3.0.tgz",
+      "integrity": "sha512-f4Nev0dvJmWQPbXLYu4BF17agLWS6iQ+vanPlWkEaa4MAjbClD/YrQaR8w9vY+C472crSp3kRGHJXIQzSwgMpw==",
       "requires": {
+        "lodash": "4.17.11",
         "prop-types": "15.7.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-native-app-settings": "github:KrazyLabs/react-native-app-settings",
     "react-native-background-timer": "^2.1.0-alpha.6",
     "react-native-blur-overlay": "github:yasharAyari/react-native-blur-overlay",
-    "react-native-camera": "^1.3.0",
+    "react-native-camera": "=1.3.0",
     "react-native-camera-roll-picker": "^1.2.3",
     "react-native-crypto": "^2.1.2",
     "react-native-dropdownalert": "^3.9.2",


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #784

### How did I fix it?
Updated package.json and package-lock.json to use 1.3.0 version of `react-native-camera`

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
```bash
$ cd lisk-mobile
$ rm -rf node_modules
$ npm cache clean --force
$ npm install
```


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
