### PR TITLE
Fix missing reference in Lisk transactions - Resolves #807

### DIFF
--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -45,14 +45,14 @@ export const transactionsLoaded = data => async (dispatch, getState) => {
  * @param {Function} errorCb - error callback
  */
 export const transactionAdded = (data, successCb, errorCb) => async (dispatch, getState) => {
-  const activeToken = getState().settings.token.active;
-  const account = getState().accounts.info[activeToken];
+  const { settings: { token }, accounts } = getState();
+  const account = accounts.info[token.active];
 
   try {
-    const tx = await transactionsAPI.create(activeToken, data);
+    const tx = await transactionsAPI.create(token.active, data);
 
-    if (activeToken === tokenMap.LSK.key) {
-      const { id } = await transactionsAPI.broadcast(activeToken, tx);
+    if (token.active === tokenMap.LSK.key) {
+      const { id } = await transactionsAPI.broadcast(token.active, tx);
 
       dispatch({
         type: actionTypes.pendingTransactionAdded,
@@ -69,7 +69,7 @@ export const transactionAdded = (data, successCb, errorCb) => async (dispatch, g
 
       successCb({ txId: id });
     } else {
-      await transactionsAPI.broadcast(activeToken, tx);
+      await transactionsAPI.broadcast(token.active, tx);
 
       dispatch(transactionsReset());
       dispatch(transactionsLoaded({ address: account.address }));

--- a/src/utilities/api/lisk/transactions.js
+++ b/src/utilities/api/lisk/transactions.js
@@ -55,14 +55,14 @@ export const create = ({
   recipientAddress,
   amount,
   secondPassphrase,
-  data,
+  reference,
 }) => new Promise((resolve) => {
   const transaction = Lisk.transaction.transfer(removeUndefinedKeys({
     passphrase,
     secondPassphrase,
     recipientId: recipientAddress,
     amount,
-    data,
+    data: reference,
   }));
 
   resolve(transaction);


### PR DESCRIPTION
# What was the bug or feature?
Described in #807 

### How did I fix it?
There was a mistake passing the reference value to the utility.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Make sure you can:
 - Send Lisk transactions with and without message/reference.
 - Send BTC transactions/

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes