### PR TITLE
Quick action discreet mode

### DIFF
--- a/src/utilities/buildQuickActions.js
+++ b/src/utilities/buildQuickActions.js
@@ -1,4 +1,6 @@
-export default [
+import { settingsUpdated } from '../actions/settings';
+
+export default async () => [
   {
     type: 'Request',
     title: 'Request tokens',
@@ -13,6 +15,15 @@ export default [
     icon: 'quick_action_send',
     userInfo: {
       url: 'lisk://wallet',
+    },
+  },
+  {
+    type: 'Discreet',
+    title: 'Open discreetly',
+    icon: 'quick_action_send',
+    userInfo: {
+      action: settingsUpdated({ incognito: true }),
+      requireSignIn: false,
     },
   },
 ];


### PR DESCRIPTION
Implements https://github.com/LiskHQ/lisk-mobile/issues/828
Code base on _development_.

Add the capacity to execute action when a quick action is pressed.
Add the "Open discreetly" quick action.

QuickActions definition objects can now set two new attributes :
- `action: Object` the action to dispatch
- `requireSignIn: bool` if the action must be dispatched after signing in

The SignIn screen now additionally checks the new attributes and act accordingly.

Important notes :

Currently the icon is the "send" icon, I'm waiting your suggestion for an appropriate one

`buildQuickActions.js` now contains an async function to allow some actions to be performed to build the items. I have tested a _toggle language_ quick action, loading the language from the `AsyncStorage` and toggling it. It -kinda- works, but if you switch too quickly, it doesn't necessarily switch. I think it is due to the `AsyncStorage.setItem` and its async caveats, and probably more random inside an emulator - test on iOS. I can't compile on my device since I don't have the appropriate certificate.