### PR TITLE
Fetch the balance in the amount step of the send screen - Closes #821

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -145,18 +145,18 @@ export const accountSignedOut = () => ({
   type: actionTypes.accountSignedOut,
 });
 
-export const accountFetched = () => (dispatch, getState) => {
-  const activeToken = getState().settings.token.active;
-  const { address } = getState().accounts.info[activeToken];
+export const accountFetched = givenToken => (dispatch, getState) => {
+  const selectedToken = givenToken || getState().settings.token.active;
+  const { address } = getState().accounts.info[selectedToken];
 
   dispatch(loadingStarted(actionTypes.accountFetched));
-  return accountAPI.getSummary(activeToken, address)
+  return accountAPI.getSummary(selectedToken, address)
     .then((account) => {
       dispatch({
         type: actionTypes.accountUpdated,
         data: {
           account,
-          activeToken,
+          activeToken: selectedToken,
         },
       });
       dispatch(loadingFinished(actionTypes.accountFetched));

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -186,6 +186,13 @@ class Home extends React.Component {
 
   componentDidMount() {
     this.props.navigation.addListener('willFocus', this.screenWillFocus);
+
+    setTimeout(() => {
+      const { activeToken, accountFetched } = this.props;
+      const inactiveToken = activeToken === tokenMap.LSK.key ? tokenMap.BTC.key : tokenMap.LSK.key;
+
+      accountFetched(inactiveToken);
+    }, 1000);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -189,9 +189,11 @@ class Home extends React.Component {
 
     setTimeout(() => {
       const { activeToken, accountFetched } = this.props;
-      const inactiveToken = activeToken === tokenMap.LSK.key ? tokenMap.BTC.key : tokenMap.LSK.key;
+      const inactiveTokens = Object.keys(tokenMap).filter(token => token !== activeToken);
 
-      accountFetched(inactiveToken);
+      inactiveTokens.forEach((token) => {
+        accountFetched(token);
+      });
     }, 1000);
   }
 


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #821.

### How did I fix it?
Since other components are also affected by not having the balance of both tokens up to date on the store (i.e. `TokenSwitcher` shows 0 balance on the inactive token unless changed manually) I've added a call to the `accountFetched` action from home with a 1000ms delay so that the performance is not affected.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Make sure the balance of both tokens are up to date throughout the app (Send, Token switcher...).


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
