### PR TITLE
Fix transaction colors - Closes #882

### DIFF
--- a/src/components/accountSummary/profile.js
+++ b/src/components/accountSummary/profile.js
@@ -11,7 +11,7 @@ import { tokenMap } from '../../constants/tokens';
 import blurBig from '../../assets/images/balanceBlur/darkBig.png';
 import blurMedium from '../../assets/images/balanceBlur/darkMedium.png';
 import blurSmall from '../../assets/images/balanceBlur/darkSmall.png';
-import { colors } from '../../constants/styleGuide';
+import { colors, themes } from '../../constants/styleGuide';
 
 const blurs = {
   blurBig, blurMedium, blurSmall,
@@ -25,6 +25,7 @@ const Profile = ({
   account,
   settings,
   token,
+  theme,
 }) => {
   const AView = Animated.View;
   let balanceSize = 'Small';
@@ -54,7 +55,7 @@ const Profile = ({
               style={styles.tokenLogo}
               name={tokenMap[token].icon}
               size={30}
-              color={colors.light.BTC}
+              color={theme === themes.light ? colors.light.BTC : colors.dark.homeHeaderBg}
             />
           </View>
         }

--- a/src/components/accountSummary/styles.js
+++ b/src/components/accountSummary/styles.js
@@ -193,7 +193,7 @@ export default () => ({
       backgroundColor: setColorOpacity(colors.dark.ultramarineBlue, 0.3),
     },
     homeContainerBTC: {
-      backgroundColor: colors.light.BTC,
+      backgroundColor: setColorOpacity(colors.dark.ultramarineBlue, 0.3),
     },
     walletContainer: {
       borderBottomWidth: 1,

--- a/src/components/router/dynamicHeaderBackground/styles.js
+++ b/src/components/router/dynamicHeaderBackground/styles.js
@@ -16,7 +16,7 @@ export default () => ({
   },
   [themes.dark]: {
     BTC: {
-      backgroundColor: colors.light.BTC,
+      backgroundColor: colors.dark.homeHeaderBg,
     },
     LSK: {
       backgroundColor: colors.dark.homeHeaderBg,

--- a/src/components/router/headerBackground/index.js
+++ b/src/components/router/headerBackground/index.js
@@ -9,7 +9,6 @@ const HeaderBackground = ({ styles, noBorder }) => {
     <View
       style={[
         styles.wrapper,
-        styles.theme.wrapper,
         styles.theme[borderType],
       ]}
     />

--- a/src/components/router/headerBackground/styles.js
+++ b/src/components/router/headerBackground/styles.js
@@ -9,25 +9,23 @@ export default () => ({
     },
   },
   [themes.light]: {
-    wrapper: {
-      backgroundColor: colors.light.headerBg,
-    },
     bordered: {
       borderBottomColor: colors.light.whiteSmoke,
+      backgroundColor: colors.light.headerBg,
     },
     nonBordered: {
       borderBottomColor: colors.light.whiteSmoke,
+      backgroundColor: colors.light.headerBg,
     },
   },
   [themes.dark]: {
-    wrapper: {
-      backgroundColor: colors.dark.headerBg,
-    },
     bordered: {
       borderBottomColor: setColorOpacity(colors.light.white, 0.24),
+      backgroundColor: colors.dark.headerBg,
     },
     nonBordered: {
       borderBottomColor: 'transparent',
+      backgroundColor: colors.dark.maastrichtBlue,
     },
   },
 });

--- a/src/components/transactions/item.js
+++ b/src/components/transactions/item.js
@@ -112,7 +112,7 @@ class Item extends React.Component {
                   trim={true}
                   tokenType={activeToken}
                   type={B}
-                  style={[styles.amount, styles.theme.amount]}
+                  style={[styles[`${direction}Amount`], styles.theme[`${direction}Amount`]]}
                 >
                   {amount}
                 </FormattedNumber>

--- a/src/components/transactions/item.js
+++ b/src/components/transactions/item.js
@@ -107,14 +107,16 @@ class Item extends React.Component {
           {
             (activeToken === 'LSK' && tx.recipientAddress === tx.senderAddress) || incognito ?
               null :
-              <FormattedNumber
-                trim={true}
-                tokenType={activeToken}
-                type={B}
-                style={[styles.amount, styles[direction], styles.theme[direction]]}
-              >
-                {amount}
-              </FormattedNumber>
+              <View style={[styles[direction], styles.theme[direction]]}>
+                <FormattedNumber
+                  trim={true}
+                  tokenType={activeToken}
+                  type={B}
+                  style={[styles.amount, styles.theme.amount]}
+                >
+                  {amount}
+                </FormattedNumber>
+              </View>
           }
           {
             (tx.type === 0 && (tx.recipientAddress !== tx.senderAddress)) && incognito ?

--- a/src/components/transactions/styles.js
+++ b/src/components/transactions/styles.js
@@ -144,14 +144,14 @@ export default () => ({
     avatar: {
       borderColor: colors.light.ghost,
     },
-    outgoing: {
+    incomingAmount: {
+      color: colors.light.ufoGreen,
+    },
+    outgoingAmount: {
       color: colors.light.black,
     },
     incoming: {
       backgroundColor: setColorOpacity(colors.light.ufoGreen, 0.15),
-    },
-    amount: {
-      color: colors.light.ufoGreen,
     },
     outgoingSymbol: {
       backgroundColor: setColorOpacity(colors.dark.black, 0.15),
@@ -182,14 +182,14 @@ export default () => ({
     avatar: {
       borderColor: colors.dark.ghost,
     },
-    outgoing: {
+    incomingAmount: {
+      color: colors.dark.ufoGreen,
+    },
+    outgoingAmount: {
       color: colors.dark.white,
     },
     incoming: {
       backgroundColor: setColorOpacity(colors.dark.ufoGreen, 0.15),
-    },
-    amount: {
-      color: colors.dark.ufoGreen,
     },
     outgoingSymbol: {
       backgroundColor: setColorOpacity(colors.dark.white, 0.15),

--- a/src/components/transactions/styles.js
+++ b/src/components/transactions/styles.js
@@ -148,8 +148,10 @@ export default () => ({
       color: colors.light.black,
     },
     incoming: {
+      backgroundColor: setColorOpacity(colors.light.ufoGreen, 0.15),
+    },
+    amount: {
       color: colors.light.ufoGreen,
-      backgroundColor: colors.light.ufoGreenTx,
     },
     outgoingSymbol: {
       backgroundColor: setColorOpacity(colors.dark.black, 0.15),
@@ -184,8 +186,10 @@ export default () => ({
       color: colors.dark.white,
     },
     incoming: {
+      backgroundColor: setColorOpacity(colors.dark.ufoGreen, 0.15),
+    },
+    amount: {
       color: colors.dark.ufoGreen,
-      backgroundColor: colors.dark.ufoGreenTx,
     },
     outgoingSymbol: {
       backgroundColor: setColorOpacity(colors.dark.white, 0.15),

--- a/src/constants/styleGuide/colors.js
+++ b/src/constants/styleGuide/colors.js
@@ -18,7 +18,6 @@ const light = {
   ...common,
   outgoingArrow: common.maastrichtBlue,
   headerBg: common.whiteSmoke,
-  ufoGreenTx: '#DFF9EB', // ufoGreen with 0.15 opacity - using setColorOpacity helper makes the color overlap itelf
 };
 
 const dark = {
@@ -28,7 +27,6 @@ const dark = {
   headerBg: '#00152D',
   // homeHeaderBg is ultramarineBlue with 30% opacity
   homeHeaderBg: '#1b316a',
-  ufoGreenTx: '#DFF9EB',
 };
 
 export default {


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #882.

### How did I fix it?
- Fixed double layer of background in amount.
- Fixed header background color.
- Corrected BTC dark mode header - only light mode has an orange background in the design.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Make sure transaction screen is identical to design.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
