### PR TITLE
i18n: Month names are not translated in Deutsch - Closes #929

### DIFF
--- a/src/components/shared/formattedDate/index.js
+++ b/src/components/shared/formattedDate/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text } from 'react-native';
 import moment from 'moment';
+import 'moment/min/locales';
 
 /**
  * Converts the timestamp to moment prettified time and wraps the value in a component
@@ -17,9 +18,12 @@ const FormattedDate = ({
   children,
   style,
   type,
+  locale,
   format = 'MMM D, YYYY',
 }) => {
   const Element = type || Text;
+
+  moment.locale(locale);
 
   return (
     <Element style={style}>

--- a/src/components/shared/transactions/item.js
+++ b/src/components/shared/transactions/item.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import LottieView from 'lottie-react-native';
 import { translate } from 'react-i18next';
+import connect from 'redux-connect-decorator';
 import { fromRawLsk } from '../../../utilities/conversions';
 import FormattedNumber from '../formattedNumber';
 import Symbol from './symbol';
@@ -16,6 +17,9 @@ import getStyles from './styles';
 
 const txTypes = ['accountInitialization', 'setSecondPassphrase', 'registerDelegate', 'vote'];
 
+@connect(state => ({
+  language: state.settings.language
+}))
 class Item extends React.Component {
   componentDidMount() {
     if (typeof this.props.tx.timestamp !== 'number') {
@@ -47,7 +51,7 @@ class Item extends React.Component {
   render() {
     const {
       styles, theme, tx, t, activeToken,
-      account, followedAccounts, incognito,
+      account, followedAccounts, incognito, language,
     } = this.props;
 
     let direction = 'incoming';
@@ -97,7 +101,7 @@ class Item extends React.Component {
             <Small style={[styles.date, styles.theme.date]}>
               {t('Pending confirmation')}
             </Small> :
-            <FormattedDate type={Small} style={[styles.date, styles.theme.date]}>
+            <FormattedDate locale={language} type={Small} style={[styles.date, styles.theme.date]}>
               {tx.timestamp}
             </FormattedDate>
           }


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #929.

### How did I fix it?
Localized the month formatting using `moment.js`.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### How to test it?
Check that dates on transactions are localized correctly on `Home`.


# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
