### PR TITLE
Fix the floating point and the thousands separators according to the users' localisation - Closes #361

### DIFF
--- a/src/components/screens/router/homeHeaderTitle/index.js
+++ b/src/components/screens/router/homeHeaderTitle/index.js
@@ -6,6 +6,7 @@ import {
   View,
   TouchableWithoutFeedback,
 } from 'react-native';
+import connect from 'redux-connect-decorator';
 import { fromRawLsk } from '../../../../utilities/conversions';
 import Avatar from '../../../shared/avatar';
 import Icon from '../../../shared/toolBox/icon';
@@ -113,34 +114,56 @@ const SimpleHeader = ({ styles, type, title, scrollY }) => (
   </Animated.Text>
 );
 
-const HomeHeaderTitle = ({ styles, theme, wallet, data, scrollToTop }) => (
-  <View style={styles.container}>
-    {data && (
-      <TouchableWithoutFeedback onPress={() => scrollToTop()}>
-        <View>
-          <SimpleHeader
-            styles={styles}
-            type={data.type}
-            title={data.placeHolder}
-            scrollY={data.scrollY}
-          />
-          <ExtendedTitle
-            balance={
-              data.balance !== undefined ? fromRawLsk(data.balance) : '0'
-            }
-            theme={theme}
-            token={data.token}
-            styles={styles}
-            scrollY={data.scrollY}
-            address={data.address}
-            incognito={data.incognito}
-            type={data.type}
-            wallet={wallet}
-          />
-        </View>
-      </TouchableWithoutFeedback>
-    )}
-  </View>
-);
+@connect(state => ({
+  language: state.settings.language,
+}))
+class HomeHeaderTitle extends React.Component {
+  normalizeBalance = balance => {
+    const { language } = this.props;
+
+    return Number(balance).toLocaleString(
+      `${language}-${language.toUpperCase()}`,
+      {
+        maximumFractionDigits: 20,
+      }
+    );
+  };
+
+  render() {
+    const { styles, theme, wallet, data, scrollToTop } = this.props;
+
+    return (
+      <View style={styles.container}>
+        {data && (
+          <TouchableWithoutFeedback onPress={() => scrollToTop()}>
+            <View>
+              <SimpleHeader
+                styles={styles}
+                type={data.type}
+                title={data.placeHolder}
+                scrollY={data.scrollY}
+              />
+              <ExtendedTitle
+                balance={
+                  data.balance
+                    ? this.normalizeBalance(fromRawLsk(data.balance))
+                    : '0'
+                }
+                theme={theme}
+                token={data.token}
+                styles={styles}
+                scrollY={data.scrollY}
+                address={data.address}
+                incognito={data.incognito}
+                type={data.type}
+                wallet={wallet}
+              />
+            </View>
+          </TouchableWithoutFeedback>
+        )}
+      </View>
+    );
+  }
+}
 
 export default withTheme(HomeHeaderTitle, getStyles());

--- a/src/components/screens/tabs/home/accountSummary/profile.js
+++ b/src/components/screens/tabs/home/accountSummary/profile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image, Animated, View } from 'react-native';
+import connect from 'redux-connect-decorator';
 import Avatar from '../../../../shared/avatar';
 import { fromRawLsk } from '../../../../../utilities/conversions';
 import FormattedNumber from '../../../../shared/formattedNumber';
@@ -19,100 +20,110 @@ const blurs = {
   blurSmall,
 };
 
-const Profile = ({
-  styles,
-  priceTicker,
-  interpolate,
-  height,
-  account,
-  settings,
-  token,
-  theme,
-}) => {
-  const AView = Animated.View;
-  let balanceSize = 'Small';
+@connect(state => ({
+  language: state.settings.language,
+}))
+class Profile extends React.Component {
+  render() {
+    const {
+      styles,
+      priceTicker,
+      interpolate,
+      height,
+      account,
+      settings,
+      token,
+      theme,
+      language,
+    } = this.props;
+    const AView = Animated.View;
+    let balanceSize = 'Small';
 
-  const normalizedBalance = fromRawLsk(account.balance);
-  if (normalizedBalance.length > 6) balanceSize = 'Big';
-  else if (normalizedBalance.length > 2) balanceSize = 'Medium';
+    const normalizedBalance = fromRawLsk(account.balance);
+    if (normalizedBalance.length > 6) balanceSize = 'Big';
+    else if (normalizedBalance.length > 2) balanceSize = 'Medium';
 
-  let faitBalance = 0;
-  const ratio = priceTicker[token][settings.currency];
-  if (normalizedBalance && ratio) {
-    faitBalance = (normalizedBalance * ratio).toFixed(2);
-  }
+    let fiatBalance = 0;
+    const ratio = priceTicker[token][settings.currency];
+    if (normalizedBalance && ratio) {
+      fiatBalance = (normalizedBalance * ratio).toLocaleString(
+        `${language}-${language.toUpperCase()}`,
+        { maximumFractionDigits: 2 }
+      );
+    }
 
-  return (
-    <View testID="accountSummary">
-      <AView
-        style={[
-          styles.avatarContainer,
-          { marginTop: interpolate([0, 100], [0, 100]) },
-        ]}
-      >
-        {token === 'LSK' ? (
-          <Avatar address={account.address} size={50} />
-        ) : (
-          <View style={styles.tokenLogoWrapper}>
-            <Icon
-              style={styles.tokenLogo}
-              name={tokenMap[token].icon}
-              size={30}
-              color={
-                theme === themes.light
-                  ? colors.light.BTC
-                  : colors.dark.homeHeaderBg
-              }
-            />
-          </View>
-        )}
-      </AView>
-
-      <AView
-        style={[
-          styles.balance,
-          {
-            opacity: interpolate([0, height - 120, height - 85], [1, 1, 0]),
-            top: interpolate([0, height - 50], [0, height - 120]),
-          },
-        ]}
-      >
-        <FormattedNumber
-          tokenType={token}
+    return (
+      <View testID="accountSummary">
+        <AView
           style={[
-            styles.theme.homeBalance,
-            settings.incognito ? styles.invisibleTitle : null,
+            styles.avatarContainer,
+            { marginTop: interpolate([0, 100], [0, 100]) },
           ]}
-          type={H3}
         >
-          {normalizedBalance}
-        </FormattedNumber>
-        <Image
-          source={blurs[`blur${balanceSize}`]}
+          {token === 'LSK' ? (
+            <Avatar address={account.address} size={50} />
+          ) : (
+            <View style={styles.tokenLogoWrapper}>
+              <Icon
+                style={styles.tokenLogo}
+                name={tokenMap[token].icon}
+                size={30}
+                color={
+                  theme === themes.light
+                    ? colors.light.BTC
+                    : colors.dark.homeHeaderBg
+                }
+              />
+            </View>
+          )}
+        </AView>
+
+        <AView
           style={[
-            styles.blur,
-            styles[`blur${balanceSize}`],
-            settings.incognito ? styles.visibleBlur : null,
+            styles.balance,
+            {
+              opacity: interpolate([0, height - 120, height - 85], [1, 1, 0]),
+              top: interpolate([0, height - 50], [0, height - 120]),
+            },
           ]}
-        />
-      </AView>
-      <AView
-        style={[
-          styles.fiat,
-          {
-            opacity: interpolate([0, 30], [1, 0]),
-            top: interpolate([0, 100], [0, 80]),
-          },
-        ]}
-      >
-        {!(settings.incognito || Number.isNaN(faitBalance)) ? (
-          <P style={[styles.fiatValue, styles.theme.fiatValue]}>
-            {`~ ${faitBalance} ${settings.currency}`}
-          </P>
-        ) : null}
-      </AView>
-    </View>
-  );
-};
+        >
+          <FormattedNumber
+            tokenType={token}
+            style={[
+              styles.theme.homeBalance,
+              settings.incognito ? styles.invisibleTitle : null,
+            ]}
+            type={H3}
+          >
+            {normalizedBalance}
+          </FormattedNumber>
+          <Image
+            source={blurs[`blur${balanceSize}`]}
+            style={[
+              styles.blur,
+              styles[`blur${balanceSize}`],
+              settings.incognito ? styles.visibleBlur : null,
+            ]}
+          />
+        </AView>
+        <AView
+          style={[
+            styles.fiat,
+            {
+              opacity: interpolate([0, 30], [1, 0]),
+              top: interpolate([0, 100], [0, 80]),
+            },
+          ]}
+        >
+          {!(settings.incognito || Number.isNaN(fiatBalance)) ? (
+            <P style={[styles.fiatValue, styles.theme.fiatValue]}>
+              {`~ ${fiatBalance} ${settings.currency}`}
+            </P>
+          ) : null}
+        </AView>
+      </View>
+    );
+  }
+}
 
 export default withTheme(Profile, getStyles());

--- a/src/components/screens/tabs/request/index.js
+++ b/src/components/screens/tabs/request/index.js
@@ -20,6 +20,7 @@ import { themes, colors } from '../../../../constants/styleGuide';
 import { tokenMap } from '../../../../constants/tokens';
 import Avatar from '../../../shared/avatar';
 import CopyToClipboard from '../../../shared/copyToClipboard';
+import { languageMap } from '../../../../constants/languages';
 
 const isSmallScreen = deviceHeight() < SCREEN_HEIGHTS.SM;
 const qrCodeSize = deviceWidth() * (isSmallScreen ? 0.64 : 0.72);
@@ -27,6 +28,7 @@ const qrCodeSize = deviceWidth() * (isSmallScreen ? 0.64 : 0.72);
 @connect(state => ({
   account: state.accounts.info,
   activeToken: state.settings.token.active,
+  language: state.settings.language,
 }))
 class Request extends React.Component {
   state = {
@@ -46,10 +48,14 @@ class Request extends React.Component {
   validator = str => reg.amount.test(str);
 
   changeHandler = val => {
-    const { account, activeToken } = this.props;
+    const { account, activeToken, language } = this.props;
     const { address } = account[activeToken];
 
-    val = val.replace(/,/g, '.');
+    if (language === languageMap.en.code) {
+      val = val.replace(/,/g, '.');
+    } else {
+      val = val.replace(/\./g, ',');
+    }
 
     let amountValidity = -1;
     let amount = val;

--- a/src/components/screens/tabs/send/amount/btc.js
+++ b/src/components/screens/tabs/send/amount/btc.js
@@ -15,6 +15,7 @@ import { deviceType } from '../../../../../utilities/device';
 import * as btcTransactionsAPI from '../../../../../utilities/api/btc/transactions';
 import reg from '../../../../../constants/regex';
 import DropDownHolder from '../../../../../utilities/alert';
+import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
@@ -121,8 +122,13 @@ class AmountBTC extends React.Component {
   };
 
   onAmountChange = value => {
+    const { language } = this.props;
     const normalizedValue = value.replace(/[^0-9]/g, '.');
-    value = this.localizeAmount(value);
+    if (language === languageMap.en.code) {
+      value = value.replace(/,/g, '.');
+    } else {
+      value = value.replace(/\./g, ',');
+    }
 
     this.setState({
       amount: {

--- a/src/components/screens/tabs/send/amount/btc.js
+++ b/src/components/screens/tabs/send/amount/btc.js
@@ -112,9 +112,12 @@ class AmountBTC extends React.Component {
 
   localizeAmount = amount => {
     const { language } = this.props;
-    return amount.toLocaleString(`${language}-${language.toUpperCase()}`, {
-      maximumFractionDigits: 20,
-    });
+    return Number(amount).toLocaleString(
+      `${language}-${language.toUpperCase()}`,
+      {
+        maximumFractionDigits: 20,
+      }
+    );
   };
 
   onAmountChange = value => {

--- a/src/components/screens/tabs/send/amount/btc.js
+++ b/src/components/screens/tabs/send/amount/btc.js
@@ -15,7 +15,6 @@ import { deviceType } from '../../../../../utilities/device';
 import * as btcTransactionsAPI from '../../../../../utilities/api/btc/transactions';
 import reg from '../../../../../constants/regex';
 import DropDownHolder from '../../../../../utilities/alert';
-import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
@@ -113,11 +112,9 @@ class AmountBTC extends React.Component {
 
   localizeAmount = amount => {
     const { language } = this.props;
-    let value = amount.toString();
-    if (language === languageMap.en.code) value = value.replace(/,/g, '.');
-    if (language === languageMap.de.code) value = value.replace(/\./g, ',');
-
-    return value;
+    return amount.toLocaleString(`${language}-${language.toUpperCase()}`, {
+      maximumFractionDigits: 20,
+    });
   };
 
   onAmountChange = value => {

--- a/src/components/screens/tabs/send/amount/btc.js
+++ b/src/components/screens/tabs/send/amount/btc.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { translate } from 'react-i18next';
 import { BigNumber } from 'bignumber.js';
+import connect from 'redux-connect-decorator';
 import KeyboardAwareScrollView from '../../../../shared/toolBox/keyboardAwareScrollView';
 import { includeFee, fromRawLsk } from '../../../../../utilities/conversions';
 import { merge } from '../../../../../utilities/helpers';
@@ -14,9 +15,13 @@ import { deviceType } from '../../../../../utilities/device';
 import * as btcTransactionsAPI from '../../../../../utilities/api/btc/transactions';
 import reg from '../../../../../constants/regex';
 import DropDownHolder from '../../../../../utilities/alert';
+import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
+@connect(state => ({
+  language: state.settings.language,
+}))
 class AmountBTC extends React.Component {
   state = {
     fee: 0,
@@ -106,9 +111,18 @@ class AmountBTC extends React.Component {
     return { code: 0 };
   };
 
+  localizeAmount = amount => {
+    const { language } = this.props;
+    let value = amount.toString();
+    if (language === languageMap.en.code) value = value.replace(/,/g, '.');
+    if (language === languageMap.de.code) value = value.replace(/\./g, ',');
+
+    return value;
+  };
+
   onAmountChange = value => {
     const normalizedValue = value.replace(/[^0-9]/g, '.');
-    value = value.replace(/,/g, '.');
+    value = this.localizeAmount(value);
 
     this.setState({
       amount: {
@@ -163,7 +177,7 @@ class AmountBTC extends React.Component {
       valueInCurrency = valueInCurrency === 'NaN' ? 0 : valueInCurrency;
     }
 
-    return valueInCurrency;
+    return this.localizeAmount(valueInCurrency);
   }
 
   getUnspentTransactionOutputCountToConsume() {

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -13,7 +13,6 @@ import withTheme from '../../../../shared/withTheme';
 import getStyles from './styles';
 import { deviceType } from '../../../../../utilities/device';
 import DropDownHolder from '../../../../../utilities/alert';
-import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
@@ -107,11 +106,9 @@ class AmountLSK extends React.Component {
 
   localizeAmount = amount => {
     const { language } = this.props;
-    let value = amount.toString();
-    if (language === languageMap.en.code) value = value.replace(/,/g, '.');
-    if (language === languageMap.de.code) value = value.replace(/\./g, ',');
-
-    return value;
+    return amount.toLocaleString(`${language}-${language.toUpperCase()}`, {
+      maximumFractionDigits: 20,
+    });
   };
 
   getValueInCurrency() {

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import { translate } from 'react-i18next';
+import connect from 'redux-connect-decorator';
 import KeyboardAwareScrollView from '../../../../shared/toolBox/keyboardAwareScrollView';
 import { fromRawLsk } from '../../../../../utilities/conversions';
 import reg from '../../../../../constants/regex';
@@ -12,9 +13,13 @@ import withTheme from '../../../../shared/withTheme';
 import getStyles from './styles';
 import { deviceType } from '../../../../../utilities/device';
 import DropDownHolder from '../../../../../utilities/alert';
+import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
+@connect(state => ({
+  language: state.settings.language,
+}))
 class AmountLSK extends React.Component {
   state = {
     amount: {
@@ -71,7 +76,7 @@ class AmountLSK extends React.Component {
 
   onChange = value => {
     const normalizedValue = value.replace(/[^0-9]/g, '.');
-    value = value.replace(/,/g, '.');
+    value = this.localizeAmount(value);
 
     this.setState({
       amount: {
@@ -100,6 +105,15 @@ class AmountLSK extends React.Component {
     return DropDownHolder.error(t('Error'), validity.message);
   };
 
+  localizeAmount = amount => {
+    const { language } = this.props;
+    let value = amount.toString();
+    if (language === languageMap.en.code) value = value.replace(/,/g, '.');
+    if (language === languageMap.de.code) value = value.replace(/\./g, ',');
+
+    return value;
+  };
+
   getValueInCurrency() {
     const {
       priceTicker,
@@ -122,7 +136,7 @@ class AmountLSK extends React.Component {
       valueInCurrency = valueInCurrency === 'NaN' ? 0 : valueInCurrency;
     }
 
-    return valueInCurrency;
+    return this.localizeAmount(valueInCurrency);
   }
 
   render() {

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -13,6 +13,7 @@ import withTheme from '../../../../shared/withTheme';
 import getStyles from './styles';
 import { deviceType } from '../../../../../utilities/device';
 import DropDownHolder from '../../../../../utilities/alert';
+import { languageMap } from '../../../../../constants/languages';
 
 const isAndroid = deviceType() === 'android';
 
@@ -74,8 +75,13 @@ class AmountLSK extends React.Component {
   };
 
   onChange = value => {
+    const { language } = this.props;
     const normalizedValue = value.replace(/[^0-9]/g, '.');
-    value = this.localizeAmount(value);
+    if (language === languageMap.en.code) {
+      value = value.replace(/,/g, '.');
+    } else {
+      value = value.replace(/\./g, ',');
+    }
 
     this.setState({
       amount: {

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -106,9 +106,12 @@ class AmountLSK extends React.Component {
 
   localizeAmount = amount => {
     const { language } = this.props;
-    return amount.toLocaleString(`${language}-${language.toUpperCase()}`, {
-      maximumFractionDigits: 20,
-    });
+    return Number(amount).toLocaleString(
+      `${language}-${language.toUpperCase()}`,
+      {
+        maximumFractionDigits: 20,
+      }
+    );
   };
 
   getValueInCurrency() {

--- a/src/components/shared/formattedNumber/index.js
+++ b/src/components/shared/formattedNumber/index.js
@@ -27,7 +27,8 @@ class FormattedNumber extends React.Component {
       trim && matched && matched[0] !== '0.' && matched[0] !== '-0.'
         ? matched[0].replace(/\.$/, '')
         : formatedNumber;
-    const localizedVal = Number(normalizedVal).toLocaleString(
+    const valueWithoutSeparators = normalizedVal.replace(/,/g, '');
+    const localizedVal = Number(valueWithoutSeparators).toLocaleString(
       `${language}-${language.toUpperCase()}`,
       { maximumFractionDigits: 20 }
     );

--- a/src/components/shared/formattedNumber/index.js
+++ b/src/components/shared/formattedNumber/index.js
@@ -1,30 +1,42 @@
 import React from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
+import connect from 'redux-connect-decorator';
 
 const reg2 = /-?([0-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
 
-const FormattedNumber = ({
-  val,
-  children,
-  type,
-  style,
-  trim,
-  tokenType = 'LSK',
-}) => {
-  const Element = type || Text;
-  const bigNum = new BigNumber(val || children);
-  const formatedNumber = bigNum.toFormat();
-  const matched = formatedNumber.match(reg2);
-  const normalizedVal =
-    trim && matched && matched[0] !== '0.' && matched[0] !== '-0.'
-      ? matched[0].replace(/\.$/, '')
-      : formatedNumber;
-  return (
-    <Element style={style}>
-      {normalizedVal} {tokenType}
-    </Element>
-  );
-};
+@connect(state => ({
+  language: state.settings.language,
+}))
+class FormattedNumber extends React.Component {
+  render() {
+    const {
+      val,
+      children,
+      type,
+      style,
+      trim,
+      tokenType,
+      language,
+    } = this.props;
+    const Element = type || Text;
+    const bigNum = new BigNumber(val || children);
+    const formatedNumber = bigNum.toFormat();
+    const matched = formatedNumber.match(reg2);
+    const normalizedVal =
+      trim && matched && matched[0] !== '0.' && matched[0] !== '-0.'
+        ? matched[0].replace(/\.$/, '')
+        : formatedNumber;
+    const localizedVal = Number(normalizedVal).toLocaleString(
+      `${language}-${language.toUpperCase()}`,
+      { maximumFractionDigits: 20 }
+    );
+    return (
+      <Element style={style}>
+        {localizedVal} {tokenType || 'LSK'}
+      </Element>
+    );
+  }
+}
 
 export default FormattedNumber;

--- a/src/constants/languages.js
+++ b/src/constants/languages.js
@@ -2,10 +2,12 @@ export const languageMap = {
   en: {
     symbol: 'EN',
     label: 'English',
+    code: 'en',
   },
   de: {
     symbol: 'DE',
     label: 'Deutsch',
+    code: 'de',
   },
 };
 

--- a/src/constants/regex.js
+++ b/src/constants/regex.js
@@ -1,7 +1,7 @@
 export default {
   address: /^\d{1,21}[L]$/,
   transactionId: /^[0-9]+$/,
-  amount: /^\d+(\.\d{1,8})?$/,
+  amount: /^\d+(?:[.,]\d{1,8})?$/,
   publicKey: /^[a-f0-9]{64}$/i,
   delegateName: /^[a-z0-9!@$&_.]*$/i,
 };


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. Please open an issue before starting to fix a bug or implementing a feature, in order to make sure your changes in aligned with the project goals. This way, you'll also find out if anyone else is working on a similar change.
2. Please do open a PR introducing big chunks of changes in a lot of files. instead, please consider breaking the issue into multiple smaller issues.
3. Please fill out the template below for ease of review.
-->

# What was the bug or feature?
Described in #361.

### How did I fix it?
Localised `FormattedNumber`, `Request` and `Send` according to standard rules:
- English: comma for thousands and dot for decimals.
- German: dot for thousands and comma for decimals.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

### Open questions
These changes effectively change the value of transactions turning the dot in the decimal point into a comma when the app is not in English. Any potential issues?

### How to test it?
Check all numeric values on the app in both languages.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
