### PR TITLE
Navigation Sender/recipient wallets bug fix - Closes 984

### DIFF
--- a/src/components/screens/wallet/index.js
+++ b/src/components/screens/wallet/index.js
@@ -108,29 +108,32 @@ class Wallet extends React.Component {
       loadingFinished,
       activeToken,
     } = this.props;
-
-    loadingStarted();
     const { address } = navigation.state.params;
-    const account = await accountAPI.getSummary(activeToken, { address });
-    const tx = await transactionsAPI.get(activeToken, {
-      address: this.address,
-    });
-    loadingFinished();
 
-    this.setState(
-      {
-        account,
-        transactions: {
-          confirmed: tx.data,
-          pending: [],
-          loaded: true,
-          count: tx.meta.count,
+    if (!this.address || this.address !== address) {
+      loadingStarted();
+      this.address = address;
+      const account = await accountAPI.getSummary(activeToken, { address });
+      const tx = await transactionsAPI.get(activeToken, {
+        address,
+      });
+      loadingFinished();
+
+      this.setState(
+        {
+          account,
+          transactions: {
+            confirmed: tx.data,
+            pending: [],
+            loaded: true,
+            count: tx.meta.count,
+          },
         },
-      },
-      () => {
-        this.setHeader();
-      }
-    );
+        () => {
+          this.setHeader();
+        }
+      );
+    }
   }
 
   async refresh() {
@@ -185,11 +188,6 @@ class Wallet extends React.Component {
     }
   };
 
-  componentDidMount() {
-    this.address = this.props.navigation.state.params.address;
-    this.fetchInitialData();
-  }
-
   componentDidUpdate(prevProps, prevState) {
     const { activeToken, followedAccounts } = this.props;
     const storedAccount = followedAccounts[activeToken].filter(
@@ -207,6 +205,7 @@ class Wallet extends React.Component {
     ) {
       this.setHeader();
     }
+    this.fetchInitialData();
   }
 
   render() {

--- a/src/components/screens/wallet/index.js
+++ b/src/components/screens/wallet/index.js
@@ -188,6 +188,10 @@ class Wallet extends React.Component {
     }
   };
 
+  componentDidMount() {
+    this.fetchInitialData();
+  }
+
   componentDidUpdate(prevProps, prevState) {
     const { activeToken, followedAccounts } = this.props;
     const storedAccount = followedAccounts[activeToken].filter(


### PR DESCRIPTION
# What was the bug or feature?
It is described in #984 

### How did I fix it?
By updating the variable that holds the address in wallet component. And making sure that data is fetched again.

## Type of change
Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Navigate between wallets by going into a wallet, selecting a transaction from a different sender or receiver that not the account address, then navigating to that sender or reciever wallet.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
