### PR TITLE
Initialise warnings appear every time on home screen - Closes 983

### DIFF
--- a/src/components/screens/tabs/home/index.js
+++ b/src/components/screens/tabs/home/index.js
@@ -203,10 +203,6 @@ class Home extends React.Component {
       this.refreshAccountAndTx();
       this.setHeader();
     }
-
-    setTimeout(() => {
-      this.showInitializationModal();
-    }, 1200);
   };
 
   componentDidMount() {
@@ -227,6 +223,10 @@ class Home extends React.Component {
     this.accountFetchTimeout = setTimeout(() => {
       this.fetchInactiveTokensAccounts();
     }, 1000);
+
+    setTimeout(() => {
+      this.showInitializationModal();
+    }, 1200);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
# What was the bug or feature?
It is described in #983 

### How did I fix it?
I moved initialisation to componentDidMount instead of screenWillFocus, that way the function is called just when the component is mounted, instead of being called every time the user goes to Home screen.

## Type of change
Bug fix (a non-breaking change which fixes an issue)

### How to test it?
With an account that hasn't preformed initialisation, login: the modal should appear. Then navigate to other screens and come back to Home screen, the modal should not appear.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
