### PR TITLE
Support swiss franc - Closes #980

### DIFF
--- a/src/constants/currencies.js
+++ b/src/constants/currencies.js
@@ -7,6 +7,10 @@ export const currencyMap = {
     symbol: '$',
     label: 'USD',
   },
+  CHF: {
+    symbol: 'CHF',
+    label: 'CHF',
+  },
 };
 
 export const currencyKeys = Object.keys(currencyMap);

--- a/src/store/reducers/service.test.js
+++ b/src/store/reducers/service.test.js
@@ -14,7 +14,7 @@ describe('reducers: service', () => {
   });
 
   it('should return updated state in case of actionTypes.pricesRetrieved', () => {
-    const priceTicker = { USD: 1, EUR: 1 };
+    const priceTicker = { USD: 1, EUR: 1, CHF: 1 };
     const action = {
       type: actionTypes.pricesRetrieved,
       data: {
@@ -25,7 +25,7 @@ describe('reducers: service', () => {
 
     expect(service(INITIAL_STATE, action)).toEqual({
       dynamicFees: {},
-      priceTicker: { BTC: {}, LSK: { EUR: 1, USD: 1 } },
+      priceTicker: { BTC: {}, LSK: { EUR: 1, USD: 1, CHF: 1 } },
     });
   });
 

--- a/src/utilities/api/btc/service.js
+++ b/src/utilities/api/btc/service.js
@@ -16,6 +16,7 @@ export const getPriceTicker = () =>
         } = json;
 
         resolve({
+          CHF: String(BTC.CHF),
           EUR: String(BTC.EUR),
           USD: String(BTC.USD),
         });

--- a/src/utilities/api/btc/service.test.js
+++ b/src/utilities/api/btc/service.test.js
@@ -14,6 +14,7 @@ const response = {
         RUB: 78.17433000000001,
         JPY: 133.30835668,
         CNY: 13.638946716302977,
+        CHF: 0.7833845341,
       },
       BTC: {
         GBP: '2984.57450371',
@@ -23,6 +24,7 @@ const response = {
         RUB: '253500',
         JPY: 432286,
         CNY: 44227.727856226,
+        CHF: 8159.81825053,
       },
     },
   },
@@ -43,6 +45,7 @@ describe('api/btc/service', () => {
       expect(result).toEqual({
         USD: String(response.getPriceTicker.tickers.BTC.USD),
         EUR: String(response.getPriceTicker.tickers.BTC.EUR),
+        CHF: String(response.getPriceTicker.tickers.BTC.CHF),
       });
     });
 

--- a/src/utilities/api/lisk/service.js
+++ b/src/utilities/api/lisk/service.js
@@ -16,6 +16,7 @@ export const getPriceTicker = () =>
         } = json;
 
         resolve({
+          CHF: String(LSK.CHF),
           EUR: String(LSK.EUR),
           USD: String(LSK.USD),
         });

--- a/src/utilities/api/lisk/service.test.js
+++ b/src/utilities/api/lisk/service.test.js
@@ -14,6 +14,7 @@ const response = {
         RUB: 78.17433000000001,
         JPY: 133.30835668,
         CNY: 13.638946716302977,
+        CHF: 0.7833845341,
       },
       BTC: {
         GBP: '2984.57450371',
@@ -23,6 +24,7 @@ const response = {
         RUB: '253500',
         JPY: 432286,
         CNY: 44227.727856226,
+        CHF: 8159.81825053,
       },
     },
   },
@@ -38,6 +40,7 @@ describe('api/lisk/service', () => {
       expect(result).toEqual({
         USD: String(response.getPriceTicker.tickers.LSK.USD),
         EUR: String(response.getPriceTicker.tickers.LSK.EUR),
+        CHF: String(response.getPriceTicker.tickers.LSK.CHF),
       });
     });
 


### PR DESCRIPTION
# What was the bug or feature?
It is described in #980 

### How did I fix it?
The CHF was added to currency map and to api services for BTC and LSK.

## Type of change
Enhancement (a non-breaking change which adds functionality)

### How to test it?
Select CHF as currency. Go to Home Screen and check if the Account summary shows the value i LSK and CHF, and then in BTC and CHF. Go to send screen, choose a recipient and on the amount screen input an amount, check if the value is shown in CHF above the input field.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
