### PR TITLE
Register button is no visible when keyboard is open - Bug fix - Closes #957

### DIFF
--- a/src/components/screens/signIn/form/index.js
+++ b/src/components/screens/signIn/form/index.js
@@ -217,13 +217,14 @@ class Form extends React.Component {
           button={t('Sign in')}
           buttonTestID="signInButton"
           onSubmit={this.onFormSubmission}
-        >
-          <CreateAccount
-            style={styles.createAccountWrapper}
-            onPress={this.goToRegistration}
-            opacity={opacity}
-          />
-        </KeyboardAwareScrollView>
+          extraContent={
+            <CreateAccount
+              style={styles.createAccountWrapper}
+              onPress={this.goToRegistration}
+              opacity={opacity}
+            />
+          }
+        />
       </View>
     );
   }

--- a/src/components/screens/signIn/form/styles.js
+++ b/src/components/screens/signIn/form/styles.js
@@ -62,8 +62,7 @@ const styles = {
     color: colors.light.ultramarineBlue,
   },
   createAccountWrapper: {
-    position: 'absolute',
-    bottom: deviceType() === 'iOSx' ? 105 : 70,
+    marginBottom: deviceType() === 'iOSx' ? 35 : 10,
   },
 };
 

--- a/src/components/shared/toolBox/keyboardAwareScrollView.js
+++ b/src/components/shared/toolBox/keyboardAwareScrollView.js
@@ -36,7 +36,13 @@ class ScrollAwareActionBar extends React.Component {
   };
 
   render() {
-    const { children, styles, viewIsInsideTab, noFooterButton } = this.props;
+    const {
+      children,
+      styles,
+      viewIsInsideTab,
+      noFooterButton,
+      extraContent,
+    } = this.props;
     const { buttonStyle } = this.state;
 
     /*
@@ -76,6 +82,7 @@ class ScrollAwareActionBar extends React.Component {
                   shouldBeOptimizedForIphoneX ? theme.iPhoneXMargin : null,
                 ]}
               >
+                {extraContent}
                 {this.renderButton(theme.footerButton)}
               </View>
             )}
@@ -83,6 +90,7 @@ class ScrollAwareActionBar extends React.Component {
         </KeyboardAwareScrollView>
         {buttonStyle === theme.keyboardStickyButton && (
           <KeyboardTrackingView>
+            {extraContent}
             {this.renderButton(theme.keyboardStickyButton)}
           </KeyboardTrackingView>
         )}


### PR DESCRIPTION
# What was the bug or feature?
It is described in #957.

### How did I fix it?
I added a prop to KeyboardAwardScrollView that can receive extra content that should stick to the bottom of the component.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Go to sign in screen. When the keyboard is closed, you should able to see the sign in button as well as the link to register. Click on the passphrase input, the keyboard will open, you should be able to continue to seen both the sign in button as the link to register.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
