### PR TITLE
iMessage app does not open received request templates - Closes #1004

### DIFF
--- a/src/components/screens/tabs/home/accountSummary/profile.js
+++ b/src/components/screens/tabs/home/accountSummary/profile.js
@@ -94,6 +94,7 @@ class Profile extends React.Component {
               settings.incognito ? styles.invisibleTitle : null,
             ]}
             type={H3}
+            language={language}
           >
             {normalizedBalance}
           </FormattedNumber>

--- a/src/components/screens/tabs/send/amount/balance/index.js
+++ b/src/components/screens/tabs/send/amount/balance/index.js
@@ -17,6 +17,7 @@ const AmountBalance = ({
   incognito,
   value = 0,
   tokenType,
+  language,
 }) => (
   <View
     style={[
@@ -36,6 +37,7 @@ const AmountBalance = ({
         type={B}
         style={[styles.balanceNumber, styles.theme.balanceNumber]}
         tokenType={tokenType}
+        language={language}
       >
         {value}
       </FormattedNumber>

--- a/src/components/screens/tabs/send/amount/btc.js
+++ b/src/components/screens/tabs/send/amount/btc.js
@@ -223,7 +223,7 @@ class AmountBTC extends React.Component {
   };
 
   render() {
-    const { accounts, styles, t, settings, dynamicFees } = this.props;
+    const { accounts, styles, t, settings, dynamicFees, language } = this.props;
     const { amount, dynamicFeeType } = this.state;
     const balance = fromRawLsk(accounts.info[settings.token.active].balance);
 
@@ -242,6 +242,7 @@ class AmountBTC extends React.Component {
               value={balance}
               tokenType={settings.token.active}
               incognito={settings.incognito}
+              language={language}
             />
 
             <Input
@@ -263,6 +264,7 @@ class AmountBTC extends React.Component {
               selected={dynamicFeeType}
               onChange={this.onDynamicFeeChange}
               tokenType={settings.token.active}
+              language={language}
             />
           </View>
         </KeyboardAwareScrollView>

--- a/src/components/screens/tabs/send/amount/dynamicFeeSelector/index.js
+++ b/src/components/screens/tabs/send/amount/dynamicFeeSelector/index.js
@@ -15,6 +15,7 @@ const DynamicFeeSelector = ({
   tokenType,
   onChange,
   styles,
+  language,
   t,
 }) => {
   let content;
@@ -79,6 +80,7 @@ const DynamicFeeSelector = ({
             type={P}
             tokenType={tokenType}
             style={[styles.value, styles.theme.value]}
+            language={language}
           >
             {fromRawLsk(value)}
           </FormattedNumber>

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -146,7 +146,7 @@ class AmountLSK extends React.Component {
   }
 
   render() {
-    const { accounts, styles, t, settings } = this.props;
+    const { accounts, styles, t, settings, language } = this.props;
     const { amount } = this.state;
 
     return (
@@ -164,6 +164,7 @@ class AmountLSK extends React.Component {
               value={fromRawLsk(accounts.info[settings.token.active].balance)}
               tokenType={settings.token.active}
               incognito={settings.incognito}
+              language={language}
             />
 
             <Input

--- a/src/components/screens/tabs/send/overview/index.js
+++ b/src/components/screens/tabs/send/overview/index.js
@@ -35,7 +35,9 @@ const getTranslatedMessages = t => ({
 });
 
 @connect(
-  null,
+  state => ({
+    language: state.settings.language,
+  }),
   {
     transactionAdded: transactionAddedAction,
   }
@@ -151,6 +153,7 @@ class Overview extends React.Component {
       accounts: { followed },
       sharedData: { address, amount, reference, fee },
       settings: { token },
+      language,
     } = this.props;
 
     const actionType =
@@ -225,7 +228,10 @@ class Overview extends React.Component {
                   : t('Amount')}
               </P>
               <B style={[styles.text, styles.theme.text]}>
-                <FormattedNumber tokenType={settings.token.active}>
+                <FormattedNumber
+                  tokenType={settings.token.active}
+                  language={language}
+                >
                   {amount}
                 </FormattedNumber>
               </B>
@@ -246,7 +252,10 @@ class Overview extends React.Component {
                   {t('Transaction fee')}
                 </P>
                 <B style={[styles.text, styles.theme.text]}>
-                  <FormattedNumber tokenType={settings.token.active}>
+                  <FormattedNumber
+                    tokenType={settings.token.active}
+                    language={language}
+                  >
                     {fromRawLsk(fee)}
                   </FormattedNumber>
                 </B>

--- a/src/components/screens/txDetail/btcSummary.js
+++ b/src/components/screens/txDetail/btcSummary.js
@@ -10,7 +10,14 @@ import Blur from '../../shared/transactions/blur';
 import getStyles from './styles';
 import { colors } from '../../../constants/styleGuide';
 
-const BtcSummary = ({ styles, theme, tx, accountAddress, incognito }) => {
+const BtcSummary = ({
+  styles,
+  theme,
+  tx,
+  accountAddress,
+  incognito,
+  language,
+}) => {
   const amount = fromRawLsk(tx.amount);
   let amountStyle = [styles.outgoing, styles.theme.outgoing];
   let amountSign = '-';
@@ -42,7 +49,7 @@ const BtcSummary = ({ styles, theme, tx, accountAddress, incognito }) => {
       {!incognito ? (
         <H3 style={amountStyle}>
           {amountSign}
-          <FormattedNumber tokenType="BTC">
+          <FormattedNumber tokenType="BTC" language={language}>
             {fromRawLsk(tx.amount)}
           </FormattedNumber>
         </H3>

--- a/src/components/screens/txDetail/index.js
+++ b/src/components/screens/txDetail/index.js
@@ -29,6 +29,7 @@ import { tokenMap } from '../../../constants/tokens';
     followedAccounts: state.accounts.followed || [],
     account: state.accounts.info || {},
     activeToken: state.settings.token.active,
+    language: state.settings.language,
   }),
   {}
 )
@@ -213,7 +214,14 @@ class TransactionDetail extends React.Component {
   };
 
   render() {
-    const { navigation, styles, account, t, activeToken } = this.props;
+    const {
+      navigation,
+      styles,
+      account,
+      t,
+      activeToken,
+      language,
+    } = this.props;
     const { tx, error, refreshing, upvotes, downvotes } = this.state;
 
     if (error) {
@@ -252,12 +260,14 @@ class TransactionDetail extends React.Component {
             incognito={incognito}
             accountAddress={walletAccountAddress}
             tx={tx}
+            language={language}
           />
         ) : (
           <BtcSummary
             incognito={incognito}
             accountAddress={walletAccountAddress}
             tx={tx}
+            language={language}
           />
         )}
 
@@ -300,7 +310,7 @@ class TransactionDetail extends React.Component {
         )}
         <Row icon="tx-fee" title="Transaction fee">
           <B style={[styles.value, styles.theme.value]}>
-            <FormattedNumber tokenType={activeToken}>
+            <FormattedNumber tokenType={activeToken} language={language}>
               {fromRawLsk(tx.fee)}
             </FormattedNumber>
           </B>

--- a/src/components/screens/txDetail/lskSummary.js
+++ b/src/components/screens/txDetail/lskSummary.js
@@ -21,7 +21,15 @@ const txTypes = [
   'vote',
 ];
 
-const LskSummary = ({ styles, theme, t, tx, accountAddress, incognito }) => {
+const LskSummary = ({
+  styles,
+  theme,
+  t,
+  tx,
+  accountAddress,
+  incognito,
+  language,
+}) => {
   const amount = fromRawLsk(tx.amount);
   let arrowStyle;
   let amountStyle = [styles.outgoing, styles.theme.outgoing];
@@ -67,7 +75,9 @@ const LskSummary = ({ styles, theme, t, tx, accountAddress, incognito }) => {
       !incognito ? (
         <H3 style={amountStyle}>
           {amountSign}
-          <FormattedNumber>{fromRawLsk(tx.amount)}</FormattedNumber>
+          <FormattedNumber language={language}>
+            {fromRawLsk(tx.amount)}
+          </FormattedNumber>
         </H3>
       ) : null}
       {tx.type === 0 &&

--- a/src/components/screens/wallet/accountSummary/index.js
+++ b/src/components/screens/wallet/accountSummary/index.js
@@ -27,7 +27,7 @@ import modalHolder from '../../../../utilities/modal';
     followedAccounts: state.accounts.followed,
     settings: state.settings,
     activeToken: state.settings.token.active,
-    language: state.settings.language
+    language: state.settings.language,
   }),
   {
     accountFollowed: accountFollowedAction,

--- a/src/components/screens/wallet/accountSummary/index.js
+++ b/src/components/screens/wallet/accountSummary/index.js
@@ -27,6 +27,7 @@ import modalHolder from '../../../../utilities/modal';
     followedAccounts: state.accounts.followed,
     settings: state.settings,
     activeToken: state.settings.token.active,
+    language: state.settings.language
   }),
   {
     accountFollowed: accountFollowedAction,
@@ -117,6 +118,7 @@ class AccountSummary extends React.Component {
       settings: { token },
       theme,
       navigation,
+      language,
     } = this.props;
     const address =
       token.active === tokenKeys[1]
@@ -198,6 +200,7 @@ class AccountSummary extends React.Component {
             tokenType={token.active}
             style={styles.theme.walletBalance}
             type={H2}
+            language={language}
           >
             {normalizedBalance}
           </FormattedNumber>

--- a/src/components/shared/formattedNumber/index.js
+++ b/src/components/shared/formattedNumber/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
+import { languageMap } from '../../../constants/languages';
 
 const reg2 = /-?([0-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
 
 class FormattedNumber extends React.Component {
   render() {
     const { val, children, type, style, trim, tokenType } = this.props;
-    const language = 'en';
+    const language = languageMap.en.code;
     const Element = type || Text;
     const bigNum = new BigNumber(val || children);
     const formatedNumber = bigNum.toFormat();

--- a/src/components/shared/formattedNumber/index.js
+++ b/src/components/shared/formattedNumber/index.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
-import { languageMap } from '../../../constants/languages';
 
 const reg2 = /-?([0-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
 
 class FormattedNumber extends React.Component {
   render() {
-    const { val, children, type, style, trim, tokenType } = this.props;
-    const language = languageMap.en.code;
+    const {
+      val,
+      children,
+      type,
+      style,
+      trim,
+      tokenType,
+      language,
+    } = this.props;
     const Element = type || Text;
     const bigNum = new BigNumber(val || children);
     const formatedNumber = bigNum.toFormat();

--- a/src/components/shared/formattedNumber/index.js
+++ b/src/components/shared/formattedNumber/index.js
@@ -1,24 +1,13 @@
 import React from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Text } from 'react-native';
-import connect from 'redux-connect-decorator';
 
 const reg2 = /-?([0-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
 
-@connect(state => ({
-  language: state.settings.language,
-}))
 class FormattedNumber extends React.Component {
   render() {
-    const {
-      val,
-      children,
-      type,
-      style,
-      trim,
-      tokenType,
-      language,
-    } = this.props;
+    const { val, children, type, style, trim, tokenType } = this.props;
+    const language = 'en';
     const Element = type || Text;
     const bigNum = new BigNumber(val || children);
     const formatedNumber = bigNum.toFormat();

--- a/src/components/shared/imessage/confirm/index.js
+++ b/src/components/shared/imessage/confirm/index.js
@@ -110,7 +110,9 @@ class Confirm extends Component {
                 <View style={styles.rowContent}>
                   <P style={styles.label}>Amount</P>
                   <B style={[styles.text]}>
-                    <FormattedNumber language={language}>{amount}</FormattedNumber>
+                    <FormattedNumber language={language}>
+                      {amount}
+                    </FormattedNumber>
                   </B>
                 </View>
               </View>
@@ -125,7 +127,7 @@ class Confirm extends Component {
                   <View style={styles.rowContent}>
                     <P style={styles.label}>Transaction fee</P>
                     <B style={[styles.text]}>
-                      <FormattedNumber language={language}>{0.1}</FormattedNumber>
+                      <FormattedNumber language={language}>0.1</FormattedNumber>
                     </B>
                   </View>
                 </View>

--- a/src/components/shared/imessage/confirm/index.js
+++ b/src/components/shared/imessage/confirm/index.js
@@ -63,6 +63,7 @@ class Confirm extends Component {
       conversation,
       message,
       state,
+      language,
       sharedData: { address, amount },
     } = this.props;
 
@@ -109,7 +110,7 @@ class Confirm extends Component {
                 <View style={styles.rowContent}>
                   <P style={styles.label}>Amount</P>
                   <B style={[styles.text]}>
-                    <FormattedNumber>{amount}</FormattedNumber>
+                    <FormattedNumber language={language}>{amount}</FormattedNumber>
                   </B>
                 </View>
               </View>
@@ -124,7 +125,7 @@ class Confirm extends Component {
                   <View style={styles.rowContent}>
                     <P style={styles.label}>Transaction fee</P>
                     <B style={[styles.text]}>
-                      <FormattedNumber>{0.1}</FormattedNumber>
+                      <FormattedNumber language={language}>{0.1}</FormattedNumber>
                     </B>
                   </View>
                 </View>

--- a/src/components/shared/imessage/index.js
+++ b/src/components/shared/imessage/index.js
@@ -9,6 +9,7 @@ import Form from './form';
 import Rejected from './rejected';
 import SignInWarning from './signInWarning';
 import DevSettings from './devSettings';
+import { languageMap } from '../../../constants/languages';
 
 const { MessagesManager } = NativeModules;
 const MessagesEvents = new NativeEventEmitter(MessagesManager);
@@ -174,6 +175,7 @@ class LiskMessageExtension extends Component {
       presentationStyle,
       conversation,
     } = this.state;
+    const language = languageMap.en.code;
 
     const isSender =
       conversation.localParticipiantIdentifier ===
@@ -190,6 +192,7 @@ class LiskMessageExtension extends Component {
                 account={{ address: address.value }}
                 sharedData={parsedData}
                 txID={parsedData.txID}
+                language={language}
               />
             );
           default:
@@ -203,6 +206,7 @@ class LiskMessageExtension extends Component {
                 sharedData={parsedData}
                 passphrase={passphrase}
                 composeMessage={this.composeMessage}
+                language={language}
               />
             );
         }

--- a/src/components/shared/imessage/txDetail/index.js
+++ b/src/components/shared/imessage/txDetail/index.js
@@ -227,7 +227,7 @@ class TransactionDetail extends React.Component {
           ) : null}
           <View style={[styles.detailRow, styles.theme.detailRow]}>
             <Icon
-              name="confirmation"
+              name="confirmations"
               size={22}
               style={styles.rowIcon}
               color={colors.light.slateGray}

--- a/src/components/shared/imessage/txDetail/index.js
+++ b/src/components/shared/imessage/txDetail/index.js
@@ -71,7 +71,7 @@ class TransactionDetail extends React.Component {
   };
 
   render() {
-    const { styles, theme, account } = this.props;
+    const { styles, theme, account, language } = this.props;
     const { tx } = this.state;
 
     if (!tx.senderAddress) {
@@ -133,7 +133,7 @@ class TransactionDetail extends React.Component {
             {tx.type === 0 && tx.recipientAddress !== tx.senderAddress ? (
               <H1 style={amountStyle}>
                 {amountSign}
-                <FormattedNumber>
+                <FormattedNumber language={language}>
                   {tx.notRawLisk ? tx.amount : fromRawLsk(tx.amount)}
                 </FormattedNumber>
               </H1>

--- a/src/components/shared/transactions/item.js
+++ b/src/components/shared/transactions/item.js
@@ -136,6 +136,7 @@ class Item extends React.Component {
                     styles[`${direction}Amount`],
                     styles.theme[`${direction}Amount`],
                   ]}
+                  language={language}
                 >
                   {amount}
                 </FormattedNumber>


### PR DESCRIPTION
# What was the bug or feature?
It is described at #1004.

### How did I fix it?
Refactored formattedNumber component, which doesn't access store anymore, instead it receives the value of language through props.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?

**For the bug:**
- Open iMessage extension, send a request to someone. (Do it in the simulator, so you can send the request and access it from the same device)
- Open the message from the recipient. A window should pop up with transaction details.

**For the refactor:**
- Go to any screen that uses formattedNumber, those being: profile, send (the whole flow), transaction detail, accountSummary and transactions.
- Just make  the screen loads normally and values are formatted as they should. 

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
