### PR TITLE
SignIn button is not sticky for android - Closes #1001

### DIFF
--- a/src/components/screens/signIn/form/index.js
+++ b/src/components/screens/signIn/form/index.js
@@ -145,10 +145,18 @@ class Form extends React.Component {
       toggleView,
       sensorType,
       showBackButton,
+      showSimplifiedView,
     } = this.props;
 
     return (
-      <View style={styles.container} testID="signInForm">
+      <View
+        style={
+          showSimplifiedView
+            ? styles.containerSimplified
+            : styles.container
+        }
+        testID="signInForm"
+      >
         {showBackButton ? (
           <BackButton toggleView={toggleView} sensorType={sensorType} t={t} />
         ) : null}
@@ -169,7 +177,11 @@ class Form extends React.Component {
           permissionDialogMessage={t('Lisk needs to connect to your camera')}
         />
 
-        <Title opacity={opacity}>{t('The official Lisk mobile wallet.')}</Title>
+        {showSimplifiedView ? null : (
+          <Title opacity={opacity}>
+            {t('The official Lisk mobile wallet.')}
+          </Title>
+        )}
 
         <Animated.View style={[{ opacity }]}>
           <Input

--- a/src/components/screens/signIn/form/index.js
+++ b/src/components/screens/signIn/form/index.js
@@ -151,9 +151,7 @@ class Form extends React.Component {
     return (
       <View
         style={
-          showSimplifiedView
-            ? styles.containerSimplified
-            : styles.container
+          showSimplifiedView ? styles.containerSimplified : styles.container
         }
         testID="signInForm"
       >

--- a/src/components/screens/signIn/form/styles.js
+++ b/src/components/screens/signIn/form/styles.js
@@ -10,6 +10,10 @@ const styles = {
     height: '100%',
     paddingTop: isSmallDevice ? 110 : 170,
   },
+  containerSimplified: {
+    height: '100%',
+    paddingTop: isSmallDevice ? 50 : 100,
+  },
   paddingBottom: {
     paddingBottom: isSmallDevice ? 0 : 40,
   },

--- a/src/components/screens/signIn/splash/index.js
+++ b/src/components/screens/signIn/splash/index.js
@@ -44,17 +44,26 @@ class Splash extends React.Component {
 
   render() {
     const { top, bgOpacity, iconOpacity } = this.state;
+    const { showSimplifiedView } = this.props;
 
     return (
       <View style={styles.splashContainer}>
         <Animated.View style={[styles.splashBg, { opacity: bgOpacity }]} />
 
         <Animated.View
-          style={[
-            styles.splashFigure,
-            styles.splashStatic,
-            { opacity: iconOpacity },
-          ]}
+          style={
+            showSimplifiedView
+              ? [
+                  styles.splashFigure,
+                  styles.splashStaticSimplified,
+                  { opacity: iconOpacity },
+                ]
+              : [
+                  styles.splashFigure,
+                  styles.splashStatic,
+                  { opacity: iconOpacity },
+                ]
+          }
         >
           <Icon
             name="lisk-full"

--- a/src/components/screens/signIn/splash/styles.js
+++ b/src/components/screens/signIn/splash/styles.js
@@ -33,6 +33,10 @@ const styles = {
     zIndex: 2,
     top: height <= 640 ? 40 : 100,
   },
+  splashStaticSimplified: {
+    zIndex: 2,
+    top: height <= 640 ? 40 : 24,
+  },
   splashAnimating: {
     zIndex: 1,
     top: '50%',

--- a/src/components/shared/toolBox/keyboardAwareScrollView.js
+++ b/src/components/shared/toolBox/keyboardAwareScrollView.js
@@ -89,7 +89,14 @@ class ScrollAwareActionBar extends React.Component {
           </View>
         </KeyboardAwareScrollView>
         {buttonStyle === theme.keyboardStickyButton && (
-          <KeyboardTrackingView>
+          <KeyboardTrackingView
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              width: '100%',
+            }}
+          >
             {extraContent}
             {this.renderButton(theme.keyboardStickyButton)}
           </KeyboardTrackingView>


### PR DESCRIPTION
# What was the bug or feature?
It is described in #1001 

### How did I fix it?
I made changes to keyboardAwareScrollView to make the button to stick to the keyboard.
Additionally, to deal with problems related to android larger keyboards that would make the bottom elements (link to register and sign-in button) to overlap the passphrase input, I made some changes to splash and form components used in signIn screen, so from a certain keyboard height / screen height ratio a simplified view would be displayed according to these [prototypes](https://projects.invisionapp.com/d/main/#/console/18879887/393231225/preview).

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Test it specially in devices that presented problems before: Samsung galaxy 8 and Google Pixel 3. In the signIn screen, click on passphrase input, the keyboard should open and:
1. SignIn button should be visible and stick to keyboard.
2. Register link should be visible above signIn button and not overlap the passphrase input.
3.  The title "The official Lisk mobile ..." should desappear
4. The above view should comply with [designs](https://projects.invisionapp.com/d/main/#/console/18879887/393231225/preview).
5. The above behaviour should stay the same as previous for ios devices and android devices that have normal size keyboards.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
