### PR TITLE
Changes on no network template - Closes #993

### DIFF
--- a/src/components/screens/tabs/home/accountSummary/profile.js
+++ b/src/components/screens/tabs/home/accountSummary/profile.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Animated, View } from 'react-native';
+import { Image, Animated, View, Dimensions } from 'react-native';
 import connect from 'redux-connect-decorator';
 import Avatar from '../../../../shared/avatar';
 import { fromRawLsk } from '../../../../../utilities/conversions';
@@ -39,13 +39,11 @@ class Profile extends React.Component {
     const AView = Animated.View;
     let balanceSize = 'Small';
 
-    const normalizedBalance = account.balance
-      ? fromRawLsk(account.balance)
-      : -1;
+    const normalizedBalance = fromRawLsk(account.balance);
     if (normalizedBalance.length > 6) balanceSize = 'Big';
     else if (normalizedBalance.length > 2) balanceSize = 'Medium';
 
-    let fiatBalance;
+    let fiatBalance = 0;
     const ratio = priceTicker[token][settings.currency];
     if (normalizedBalance && ratio) {
       fiatBalance = (normalizedBalance * ratio).toLocaleString(

--- a/src/components/screens/tabs/home/accountSummary/profile.js
+++ b/src/components/screens/tabs/home/accountSummary/profile.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Animated, View, Dimensions } from 'react-native';
+import { Image, Animated, View } from 'react-native';
 import connect from 'redux-connect-decorator';
 import Avatar from '../../../../shared/avatar';
 import { fromRawLsk } from '../../../../../utilities/conversions';

--- a/src/components/screens/tabs/home/accountSummary/profile.js
+++ b/src/components/screens/tabs/home/accountSummary/profile.js
@@ -39,11 +39,13 @@ class Profile extends React.Component {
     const AView = Animated.View;
     let balanceSize = 'Small';
 
-    const normalizedBalance = fromRawLsk(account.balance);
+    const normalizedBalance = account.balance
+      ? fromRawLsk(account.balance)
+      : -1;
     if (normalizedBalance.length > 6) balanceSize = 'Big';
     else if (normalizedBalance.length > 2) balanceSize = 'Medium';
 
-    let fiatBalance = 0;
+    let fiatBalance;
     const ratio = priceTicker[token][settings.currency];
     if (normalizedBalance && ratio) {
       fiatBalance = (normalizedBalance * ratio).toLocaleString(
@@ -91,7 +93,7 @@ class Profile extends React.Component {
             tokenType={token}
             style={[
               styles.theme.homeBalance,
-              settings.incognito ? styles.invisibleTitle : null,
+              settings.incognito || !fiatBalance ? styles.invisibleTitle : null,
             ]}
             type={H3}
           >
@@ -102,7 +104,7 @@ class Profile extends React.Component {
             style={[
               styles.blur,
               styles[`blur${balanceSize}`],
-              settings.incognito ? styles.visibleBlur : null,
+              settings.incognito || !fiatBalance ? styles.visibleBlur : null,
             ]}
           />
         </AView>
@@ -115,7 +117,11 @@ class Profile extends React.Component {
             },
           ]}
         >
-          {!(settings.incognito || Number.isNaN(fiatBalance)) ? (
+          {!(
+            settings.incognito ||
+            Number.isNaN(fiatBalance) ||
+            !fiatBalance
+          ) ? (
             <P style={[styles.fiatValue, styles.theme.fiatValue]}>
               {`~ ${fiatBalance} ${settings.currency}`}
             </P>


### PR DESCRIPTION
# What was the bug or feature?
It is described in #993 . 

### How did I fix it?
I added some logic that in case the account.balance is undefined , the account summary should be shown blurred, similar to the behaviour in discrete mode. And once the data is fetched, the screen updates and shows the values of balance in either LSK or BTC and in chosen currency.

## Type of change
Please choose one of the options:
- Bug fix (a non-breaking change which fixes an issue)

### How to test it?
Login in the application with slow network, the above described behaviour should be displayed.

# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
