### PR TITLE
Fix bug - Closes 1070

### DIFF
--- a/ios/Lisk.xcodeproj/project.pbxproj
+++ b/ios/Lisk.xcodeproj/project.pbxproj
@@ -17,10 +17,6 @@
 		2DCD954D1E0B4F2C00145EB5 /* LiskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* LiskTests.m */; };
 		41B0FB781C41C9ED638D6504 /* libPods-Lisk-LiskTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DD0FAFEDE58DEBFC3565C05 /* libPods-Lisk-LiskTests.a */; };
 		585C34B302D99F5593128505 /* libPods-Lisk-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB19C2CC2709B7103A8251B4 /* libPods-Lisk-tvOS.a */; };
-		7952112C25F765EA00CCF7F8 /* BasierCircle-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7952112925F765EA00CCF7F8 /* BasierCircle-Bold.otf */; };
-		7952112D25F765EA00CCF7F8 /* BasierCircle-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7952112A25F765EA00CCF7F8 /* BasierCircle-Regular.otf */; };
-		7952112E25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7952112B25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf */; };
-		7952113425F765F800CCF7F8 /* Gilroy-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7952113325F765F800CCF7F8 /* Gilroy-Bold.ttf */; };
 		7952113A25F7660200CCF7F8 /* icomoon.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7952113925F7660200CCF7F8 /* icomoon.ttf */; };
 		7952114225F7660F00CCF7F8 /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7952113F25F7660F00CCF7F8 /* OpenSans-Regular.ttf */; };
 		7952114325F7660F00CCF7F8 /* OpenSans-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7952114025F7660F00CCF7F8 /* OpenSans-Semibold.ttf */; };
@@ -79,10 +75,6 @@
 		385E04D251D6A018BDC54437 /* Pods-Lisk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk.release.xcconfig"; path = "Target Support Files/Pods-Lisk/Pods-Lisk.release.xcconfig"; sourceTree = "<group>"; };
 		4DD0FAFEDE58DEBFC3565C05 /* libPods-Lisk-LiskTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Lisk-LiskTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6302721A9B9A20B78728746C /* Pods-Lisk-LiskTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk-LiskTests.release.xcconfig"; path = "Target Support Files/Pods-Lisk-LiskTests/Pods-Lisk-LiskTests.release.xcconfig"; sourceTree = "<group>"; };
-		7952112925F765EA00CCF7F8 /* BasierCircle-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "BasierCircle-Bold.otf"; path = "../../src/assets/fonts/basierCircle/BasierCircle-Bold.otf"; sourceTree = "<group>"; };
-		7952112A25F765EA00CCF7F8 /* BasierCircle-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "BasierCircle-Regular.otf"; path = "../../src/assets/fonts/basierCircle/BasierCircle-Regular.otf"; sourceTree = "<group>"; };
-		7952112B25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "BasierCircle-SemiBold.otf"; path = "../../src/assets/fonts/basierCircle/BasierCircle-SemiBold.otf"; sourceTree = "<group>"; };
-		7952113325F765F800CCF7F8 /* Gilroy-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Gilroy-Bold.ttf"; path = "../../src/assets/fonts/gilroy/Gilroy-Bold.ttf"; sourceTree = "<group>"; };
 		7952113925F7660200CCF7F8 /* icomoon.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = icomoon.ttf; sourceTree = "<group>"; };
 		7952113F25F7660F00CCF7F8 /* OpenSans-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "OpenSans-Regular.ttf"; path = "../../src/assets/fonts/openSans/OpenSans-Regular.ttf"; sourceTree = "<group>"; };
 		7952114025F7660F00CCF7F8 /* OpenSans-Semibold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "OpenSans-Semibold.ttf"; path = "../../src/assets/fonts/openSans/OpenSans-Semibold.ttf"; sourceTree = "<group>"; };
@@ -222,10 +214,6 @@
 				7952113F25F7660F00CCF7F8 /* OpenSans-Regular.ttf */,
 				7952114025F7660F00CCF7F8 /* OpenSans-Semibold.ttf */,
 				7952113925F7660200CCF7F8 /* icomoon.ttf */,
-				7952113325F765F800CCF7F8 /* Gilroy-Bold.ttf */,
-				7952112925F765EA00CCF7F8 /* BasierCircle-Bold.otf */,
-				7952112A25F765EA00CCF7F8 /* BasierCircle-Regular.otf */,
-				7952112B25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -409,13 +397,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7952112E25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf in Resources */,
 				7952113A25F7660200CCF7F8 /* icomoon.ttf in Resources */,
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				7952114325F7660F00CCF7F8 /* OpenSans-Semibold.ttf in Resources */,
-				7952112C25F765EA00CCF7F8 /* BasierCircle-Bold.otf in Resources */,
-				7952113425F765F800CCF7F8 /* Gilroy-Bold.ttf in Resources */,
-				7952112D25F765EA00CCF7F8 /* BasierCircle-Regular.otf in Resources */,
 				7952114225F7660F00CCF7F8 /* OpenSans-Regular.ttf in Resources */,
 				7952114425F7660F00CCF7F8 /* OpenSans-Bold.ttf in Resources */,
 				7952114B25F7661900CCF7F8 /* Dots-Regular.ttf in Resources */,
@@ -801,6 +785,8 @@
 				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 58UK9RE9TP;
 				ENABLE_BITCODE = NO;
+				EXCLUDED_ARCHS = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = Lisk/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.4.1;
@@ -825,6 +811,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 58UK9RE9TP;
+				EXCLUDED_ARCHS = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = Lisk/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.4.1;

--- a/ios/Lisk/Info.plist
+++ b/ios/Lisk/Info.plist
@@ -71,10 +71,10 @@
 		<string>OpenSans-Semibold.ttf</string>
 		<string>OpenSans-Regular.ttf</string>
 		<string>icomoon.ttf</string>
-		<string>Gilroy-Bold.ttf</string>
+		<!-- <string>Gilroy-Bold.ttf</string>
 		<string>BasierCircle-Bold.otf</string>
 		<string>BasierCircle-Regular.otf</string>
-		<string>BasierCircle-SemiBold.otf</string>
+		<string>BasierCircle-SemiBold.otf</string> -->
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -22,9 +22,9 @@ PODS:
   - Interactable (2.0.1):
     - React
   - lottie-ios (3.1.8)
-  - lottie-react-native (3.5.0):
+  - lottie-react-native (4.0.2):
     - lottie-ios (~> 3.1.8)
-    - React
+    - React-Core
   - Permission-BluetoothPeripheral (3.0.1):
     - RNPermissions
   - Permission-Calendars (3.0.1):
@@ -530,7 +530,7 @@ SPEC CHECKSUMS:
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Interactable: 411887c89fa16ac41f8e7898aca06dcad55e5f22
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
-  lottie-react-native: 1fb4ce21d6ad37dab8343eaff8719df76035bd93
+  lottie-react-native: 4dff8fe8d10ddef9e7880e770080f4a56121397e
   Permission-BluetoothPeripheral: 9f0bd529583f759e49fdc60eaa1191b8be69f709
   Permission-Calendars: beecff003fc9fa36979f95e19cfcd54ba26a5ddf
   Permission-Camera: b2e50546c095139bb1264be9c34c796332340d32
@@ -588,4 +588,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: be43261d6486c313e6af32eebf544380979a5766
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1


### PR DESCRIPTION
update lottie dependence to 4^
update lisk client dependence
exclude arm64 from the build process

### What was the problem?
This PR resolves 1070

### How was it solved?

- [x] updated lottie-react-native to version 4ˆ
- [x] updated Lisk Client to the most recent
- [x] excluded from the build process the arm64 architecture 
- [x] commented the comercial fonts in Info.plist so the app can be built even without this fonts

### How was it tested?
Built the app in a Mac M1 and Xcode 12+ with a iPhone 11 simulator (iOS 14.3)