### PR TITLE
Update domain lisk.io to lisk.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Lisk Mobile is a cross-platform application written in React Native and primarily build for iOS and Android. It provides the users with all the functionality they need to send and receive LSK tokens, as well as reviewing the activity history of their or any other account in the Lisk blockchain.
 
-[![Get it from iTunes](https://lisk.io/sites/default/files/pictures/2020-01/download_on_the_app_store_badge.svg)](https://itunes.apple.com/us/app/lisk/id1436809559?mt=8) [![Get it on Google Play](https://lisk.io/sites/default/files/pictures/2020-01/download_on_the_play_store_badge.svg)](https://play.google.com/store/apps/details?id=io.lisk.mobile&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
+[![Get it from iTunes](https://lisk.com/sites/default/files/pictures/2020-01/download_on_the_app_store_badge.svg)](https://itunes.apple.com/us/app/lisk/id1436809559?mt=8) [![Get it on Google Play](https://lisk.com/sites/default/files/pictures/2020-01/download_on_the_play_store_badge.svg)](https://play.google.com/store/apps/details?id=io.lisk.mobile&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
 
 ## For Contributors
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.

--- a/src/constants/URLs.js
+++ b/src/constants/URLs.js
@@ -1,8 +1,8 @@
 export default {
-  liskHomepage: 'https://lisk.io/',
-  liskTermsAndConditions: 'https://lisk.io/privacy-policy-mobile',
+  liskHomepage: 'https://lisk.com/',
+  liskTermsAndConditions: 'https://lisk.com/privacy-policy-mobile',
   liskGettingStarted:
-    'https://lisk.io/academy/welcome-to-the-lisk-academy/getting-started-with-lisk',
+    'https://lisk.com/what-is-blockchain',
   BTCMinerFees: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
   BTCTestnet: 'https://btc-test.lisk.io',
   BTCMainnet: 'https://btc.lisk.io',

--- a/src/utilities/api/lisk/transactions.js
+++ b/src/utilities/api/lisk/transactions.js
@@ -12,7 +12,7 @@ const normalizeTimestamp = value =>
 
 /**
  * Normalizes transaction data retrieved from Lisk Core API
- * https://lisk.io/documentation/lisk-core/user-guide/api#/Transactions/getTransactions
+ * https://lisk.com/documentation/lisk-core/reference/api.html#/Transactions/get_transactions__id_
  */
 const normalizeTransactionsResponse = list =>
   list.map(tx => ({


### PR DESCRIPTION
### What was the problem?

- The lisk domain was changed from lisk.io to lisk.com, which was not reflected in codebase

### How was it solved?

- Updated all the domain references

### How was it tested?

- Click on new domain links and check if they navigate to correct page