### PR TITLE
Fix navigation flow from account creation to signin - Closes #1152

### DIFF
--- a/src/components/screens/register/intro/index.js
+++ b/src/components/screens/register/intro/index.js
@@ -7,6 +7,7 @@ import Slider from '../../intro/heading';
 import addressImg from '../../../../assets/images/registrationIntro/address3x.png';
 import securePassphraseImg from '../../../../assets/images/registrationIntro/securePassphrase3x.png';
 import uniqueAvatarImg from '../../../../assets/images/registrationIntro/uniqueAvatar3x.png';
+import HeaderBackButton from '../../router/headerBackButton';
 
 class Intro extends React.Component {
   state = {
@@ -25,6 +26,7 @@ class Intro extends React.Component {
 
     setOptions({
       title: t('Account creation'),
+      headerLeft: (props) => <HeaderBackButton {...props} onPress={this.props.navigation.goBack} />,
     });
   }
 

--- a/src/components/screens/router/navigationOptions.js
+++ b/src/components/screens/router/navigationOptions.js
@@ -100,7 +100,6 @@ navigationOptions.Settings = {
 
 navigationOptions.Register = {
   title: 'Account creation',
-  headerLeft: (props) => <HeaderBackButton {...props} />,
   headerRight: () => <HeaderPlaceholderButton />,
   headerStyle: noShadow,
   headerTitleStyle: genericTitle


### PR DESCRIPTION
### What was the problem?
This PR resolves #1152 

### How was it solved?
Pass a custom onPress to header navigation

### How was it tested?
iOS and Android Simulators
