### PR TITLE
Bookmark cancel button does not clear the search text - Closes #1153

### DIFF
--- a/src/components/screens/router/searchBarHeader/index.js
+++ b/src/components/screens/router/searchBarHeader/index.js
@@ -36,6 +36,11 @@ const HeaderBackButton = ({
     setIsSearchOpen(true);
   };
 
+  const closeSearchBar = () => {
+    setIsSearchOpen(false);
+    onChange('');
+  };
+
   useEffect(() => {
     if (isSearchOpen) {
       Animated.timing(width, {
@@ -69,9 +74,7 @@ const HeaderBackButton = ({
             <Input
               placeholder={t('Search for a bookmark')}
               autoCorrect={false}
-              reference={input => {
-                this.input = input;
-              }}
+              autoFocus
               innerStyles={{
                 input: [styles.input],
               }}
@@ -80,7 +83,7 @@ const HeaderBackButton = ({
               returnKeyType="search"
             />
           </View>
-          <TouchableOpacity style={styles.iconButton} onPress={() => setIsSearchOpen(false)}>
+          <TouchableOpacity style={styles.iconButton} onPress={closeSearchBar}>
             <P style={styles.cancelButton} >{t('Cancel')}</P>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
### What was the problem?
This PR resolves #1153 

### How was it solved?
Reset search query to empty string when cancel is clicked

### How was it tested?
iOS and Android Simulators
