### PR TITLE
Fix Android task hijacking vulnerability - Resolves #1093

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,12 +15,14 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:allowTaskReparenting="false"
+      android:taskAffinity="">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-        android:launchMode="singleTask"
+        android:launchMode="singleInstance"
         android:windowSoftInputMode="stateHidden|adjustResize"
          android:screenOrientation="portrait">
         <intent-filter>


### PR DESCRIPTION
### What was the problem?
This PR resolves #1093

### How was it solved?
An attacker might define their taskAfinity="io.lisk.mobile", which helps them pretend to be a task in Lisk Mobile group. but according to [Google docs](https://developer.android.com/guide/topics/manifest/activity-element#aff):

> To specify that the activity does not have an affinity for any task, set it to an empty string.

[Also](https://developer.android.com/guide/topics/manifest/activity-element#reparent),

> Whether or not the activity can move from the task that started it to the task it has an affinity for when that task is next brought to the front — "true" if it can move, and "false" if it must remain with the task where it started.

Therefore setting this value to false prevents it from being transferred to task. The default value is "false" but we explicitly reset it to prevent any misusage.

