### PR TITLE
App crashes on signout - Closes #1174

### DIFF
--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -198,9 +198,10 @@ const AmountLSK = (props) => {
     if (!validateAmount(str)) {
       message = t('The amount value is invalid.');
     } else if (
-      accounts.info[token.active].balance < fee
-      // eslint-disable-next-line no-undef
-      || parseFloat(str) > fromRawLsk(BigInt(accounts.info[token.active].balance) - fee)
+      accounts.info[token.active].balance
+        && (accounts.info[token.active].balance < fee
+        // eslint-disable-next-line no-undef
+        || parseFloat(str) > fromRawLsk(BigInt(accounts.info[token.active].balance) - fee))
     ) {
       message = t('Your balance is not sufficient.');
     }

--- a/src/utilities/api/lisk/apiClient.js
+++ b/src/utilities/api/lisk/apiClient.js
@@ -29,7 +29,6 @@ class LiskAPIClient {
         initialized: true
       };
     }
-    console.log(data)
     const unlockingAmount = data[0].dpos.unlocking
       ?.reduce?.((a, b) => a + Number(b.amount), 0) ?? 0;
     const totalSentVotes = data[0].dpos.sentVotes?.reduce?.((a, b) => a + Number(b.amount), 0) ?? 0;

--- a/src/utilities/api/lisk/apiClient.js
+++ b/src/utilities/api/lisk/apiClient.js
@@ -29,6 +29,7 @@ class LiskAPIClient {
         initialized: true
       };
     }
+    console.log(data)
     const unlockingAmount = data[0].dpos.unlocking
       ?.reduce?.((a, b) => a + Number(b.amount), 0) ?? 0;
     const totalSentVotes = data[0].dpos.sentVotes?.reduce?.((a, b) => a + Number(b.amount), 0) ?? 0;

--- a/src/utilities/helpers.js
+++ b/src/utilities/helpers.js
@@ -53,8 +53,8 @@ export const merge = (...rest) => Object.assign({}, ...rest);
  *
  * @returns {String} - the shortened string
  */
-export const stringShortener = (str = '', leftPadd = 10, rightPadd = 0) => {
-  if (str.length > 15) {
+export const stringShortener = (str, leftPadd = 10, rightPadd = 0) => {
+  if (str && str.length > 15) {
     return `${str.substr(0, leftPadd)}...${rightPadd ? str.substr(-1 * rightPadd) : ''}`;
   }
   return str;

--- a/src/utilities/helpers.js
+++ b/src/utilities/helpers.js
@@ -53,7 +53,7 @@ export const merge = (...rest) => Object.assign({}, ...rest);
  *
  * @returns {String} - the shortened string
  */
-export const stringShortener = (str, leftPadd = 10, rightPadd = 0) => {
+export const stringShortener = (str = '', leftPadd = 10, rightPadd = 0) => {
   if (str.length > 15) {
     return `${str.substr(0, leftPadd)}...${rightPadd ? str.substr(-1 * rightPadd) : ''}`;
   }

--- a/src/utilities/helpers.test.js
+++ b/src/utilities/helpers.test.js
@@ -122,6 +122,11 @@ describe('helpers', () => {
         'test_test_..._test'
       );
     });
+
+    it('should return undefined/null when str is undefined or null', () => {
+      expect(stringShortener(null)).toBeNull();
+      expect(stringShortener()).toBeUndefined();
+    });
   });
 
   describe('removeUndefinedKeys', () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1174

### How was it solved?
Assigned default empty string to params taken in by the string shortener utils as the cause of the crash is due to an undefined being passed when the app clears it's cache on sign-out.

See error below:
![Screenshot 2021-12-17 at 10 36 57](https://user-images.githubusercontent.com/28750984/146523595-21f65f0f-b33d-42d2-b331-95b6ce360d2e.png)


### How was it tested?
iOS Simulator (repeatedly signed in and signed out)
