### PR TITLE
Fix double navigation when activity is tapped twice - Closes #1192

### DIFF
--- a/src/components/screens/tabs/home/index.js
+++ b/src/components/screens/tabs/home/index.js
@@ -275,7 +275,7 @@ class Home extends React.Component {
                 type="home"
                 transactions={transactions}
                 footer={this.state.footer}
-                navigate={navigation.push}
+                navigate={navigation.navigate}
                 account={account[activeToken]}
                 refreshing={refreshing}
               />


### PR DESCRIPTION
### What was the problem?
This PR resolves #1192 

### How was it solved?
Change navigation method from `push` to `navigate`

### How was it tested?
Android and iOS Simulators
