### PR TITLE
Scan and send message not working on mobile - Closes #1210

### DIFF
--- a/src/utilities/qrCode.js
+++ b/src/utilities/qrCode.js
@@ -11,7 +11,7 @@ export const decodeLaunchUrl = data => {
       ? data.match(amountReg)[0].replace('amount=', '')
       : '';
     const reference = data.match(referenceReg)
-      ? data.match(referenceReg)[0].replace('reference=', '')
+      ? window.decodeURIComponent(data.match(referenceReg)[0].replace('reference=', ''))
       : '';
 
     return { address, amount, reference };

--- a/src/utilities/qrCode.test.js
+++ b/src/utilities/qrCode.test.js
@@ -10,6 +10,15 @@ describe('QR Code Helper', () => {
     });
   });
 
+  it('decodes QR data that contains URL and reference with space', () => {
+    const data = 'lisk://wallet?recipient=1L&amount=1&reference=test%20mobile';
+    expect(qrCode.decodeLaunchUrl(data)).toEqual({
+      address: '1L',
+      amount: '1',
+      reference: 'test mobile',
+    });
+  });
+
   it('decodes QR data just address', () => {
     const data = '1L';
     expect(qrCode.decodeLaunchUrl(data)).toEqual({


### PR DESCRIPTION
### What was the problem?
Reference message is not decoded properly when using scan to send on mobile - Closes #1210 

### How was it solved?
Parse and decode URL-encoding string generated from the QR scanner to ASCII Value

### How was it tested?
Android simulator
