### PR TITLE
Fix activity pane stuck on refresh iOS - Closes #1228

### DIFF
--- a/src/components/shared/infiniteScrollView/index.js
+++ b/src/components/shared/infiniteScrollView/index.js
@@ -52,11 +52,10 @@ class InfiniteScrollView extends React.Component {
 
   onRefresh = () => {
     this.setState({ refreshing: true });
-    this.props.refresh().then(() => {
-      setTimeout(() => {
-        this.setState({ refreshing: false });
-      }, 2000);
-    });
+    this.props.refresh();
+    setTimeout(() => {
+      this.setState({ refreshing: false });
+    }, 2000);
   };
 
   render() {
@@ -67,7 +66,6 @@ class InfiniteScrollView extends React.Component {
         contentContainerStyle={[this.props.contentContainerStyle]}
         refreshControl={
           <RefreshControl
-            progressViewOffset={170}
             onRefresh={this.onRefresh}
             refreshing={this.state.refreshing}
             tintColor={


### PR DESCRIPTION
### What was the problem?
This PR resolves #1228 

### How was it solved?
Moved setTimeout outside the refresh call as props.refresh does not return a promise

### How was it tested?
iOS Simulator
