### PR TITLE
Bugfix continue button overlay - Closes #1261

### DIFF
--- a/src/components/shared/toolBox/keyboardAwareScrollView.js
+++ b/src/components/shared/toolBox/keyboardAwareScrollView.js
@@ -50,19 +50,19 @@ const ScrollAwareActionBar = ({
       >
         <View style={[styles ? styles.innerContainer : null, theme.scrollViewInnerContainer]}>
           {children}
-          {!noFooterButton && (
-            <View
-              style={[
-                theme.footerButtonContainer,
-                shouldBeOptimizedForIphoneX ? theme.iPhoneXMargin : null
-              ]}
-            >
-              {extraContent}
-              {renderButton(theme.footerButton)}
-            </View>
-          )}
         </View>
       </KeyboardAwareScrollView>
+      {!noFooterButton && (
+        <View
+          style={[
+            theme.footerButtonContainer,
+            shouldBeOptimizedForIphoneX ? theme.iPhoneXMargin : null
+          ]}
+        >
+          {extraContent}
+          {renderButton(theme.footerButton)}
+        </View>
+      )}
     </Fragment>
   );
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1261 

### How was it solved?
Moved button render outside KeyboardAvoidingView

### How was it tested?
android device and iOS Simulator
