### PR TITLE
Fallback default active token to LSK

### DIFF
--- a/src/store/reducers/settings.js
+++ b/src/store/reducers/settings.js
@@ -20,14 +20,15 @@ export const INITIAL_STATE = {
  * If the settings read from the Async storage
  * indicates a fiat currency that is not active anymore
  * this function reverts to Euro.
- *
+ * It also makes the default selected active token to LSK
  * @param {Object} settings - Full settings Object
  * @returns {Object} Setting object
  */
-const fallbackToEUR = (settings) => {
+const fallback = (settings) => {
   settings.currency = currencyKeys.includes(settings.currency)
     ? settings.currency
     : currencyKeys[0];
+  settings.token.active = tokenKeys[0];
   return settings;
 };
 
@@ -71,7 +72,7 @@ const settings = (state = INITIAL_STATE, action = {}) => {
         },
       });
     case actionTypes.settingsRetrieved:
-      return merge(state, fallbackToEUR(action.data));
+      return merge(state, fallback(action.data));
     default:
       return state;
   }

--- a/src/store/reducers/settings.test.js
+++ b/src/store/reducers/settings.test.js
@@ -1,5 +1,6 @@
 import settings, { INITIAL_STATE } from './settings';
 import actionTypes from '../../constants/actions';
+import { tokenKeys } from '../../constants/tokens';
 
 const defaultTokens = {
   active: 'LSK',
@@ -154,6 +155,25 @@ describe('Reducers: Settings', () => {
         currency: 'EUR',
         sensorType: 'Face ID',
         token: defaultTokens,
+      });
+    });
+    it('should fallback active token to LSK and currency to EUR', () => {
+      const action = {
+        type: actionTypes.settingsRetrieved,
+        data: {
+          token: {
+            active: tokenKeys[1]
+          }
+        },
+      };
+      const state = {};
+
+      const changedState = settings(state, action);
+      expect(changedState).toEqual({
+        currency: 'EUR',
+        token: {
+          active: tokenKeys[0]
+        }
       });
     });
   });


### PR DESCRIPTION
### What was the problem?
This PR resolves #1265 

### How was it solved?
Have a fallback for active token to LSK everytime settings is retrieved

### How was it tested?
Android and iOS simulator
- Set default active token to BTC
- Re-run the app and ensure it's changed to LSK
