### PR TITLE
Fix send maximum balance calculation - Closes #1254

### DIFF
--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -85,9 +85,7 @@ const AmountLSK = (props) => {
   const onChange = (text, isMaximum) => {
     const { language, t } = props;
     try {
-      if (!isMaximum) {
-        setIsMaximum(false);
-      }
+      setIsMaximum(!!isMaximum);
       transactions.convertLSKToBeddows(text);
       if (!isNumeric(text)) {
         throw Error(`Invalid amount ${text}`);

--- a/src/hooks/transactionFee/useTransactionFeeCalculation.js
+++ b/src/hooks/transactionFee/useTransactionFeeCalculation.js
@@ -91,6 +91,7 @@ const useTransactionFeeCalculation = ({
   const [state, dispatch] = useReducer(reducer, account, getInitialState);
   const calculateTransactionFees = async (params) => {
     const fee = await getTransactionFee(params);
+
     dispatch({ type: actionTypes.setFee, payload: { response: fee, account, token } });
 
     const minFee = await getTransactionFee(
@@ -102,10 +103,11 @@ const useTransactionFeeCalculation = ({
     );
 
     dispatch({ type: actionTypes.setMinFee, payload: { response: minFee, account, token } });
+
     const maxAmountFee = await getTransactionFee(
       {
         ...params,
-        transaction: { ...params.transaction, amount: account.balance },
+        transaction: { ...params.transaction, amount: fromRawLsk(account.balance) },
         selectedPriorityIndex
       }
     );

--- a/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
+++ b/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
@@ -33,7 +33,7 @@ describe('useTransactionFeeCalculation', () => {
     expect(Number(result.current.maxAmount.value)).toBeLessThan(18997997000);
   });
 
-  it('should calculate correctly for maximum balance', async () => {
+  it('should have minimum balance of 0.05LSK when a user sends maximum balance', async () => {
     const firstRender = renderHook(() =>
       useTransactionFeeCalculation({ ...props }));
     await firstRender.waitForValueToChange(() => firstRender.result.current.maxAmount.value);

--- a/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
+++ b/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
@@ -28,7 +28,7 @@ describe('useTransactionFeeCalculation', () => {
     await waitForValueToChange(() => result.current.maxAmount.value);
     expect(Number(result.current.fee.value)).toEqual(0.00138);
     expect(Number(result.current.minFee.value)).toEqual(0.00138);
-    expect(Number(result.current.maxAmount.value)).toEqual(18992851000);
+    expect(Number(result.current.maxAmount.value)).toEqual(18992855000);
     expect(Number(result.current.maxAmount.value)).toBeLessThan(18997997000);
   });
 });


### PR DESCRIPTION
### What was the problem?
This PR resolves #1254 

### How was it solved?
Convert from lsk the total user balance passed to fee calculation

### How was it tested?
- iOS Simulator
