### PR TITLE
Fix negative max amount calculation and validate sending lsk adding transaction fee - Closes #1280 #1282

### DIFF
--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -222,7 +222,7 @@ const AmountLSK = (props) => {
     const { amount, errorMessage } = state;
     if (errorMessage !== '') return;
     const transactionPriority = priority ? priority[selectedPriority] : null;
-    if (Number(amount) > Number(fromRawLsk(maxAmount.value))) {
+    if (Number(amount) + fee.value > Number(fromRawLsk(maxAmount.value))) {
       DropDownHolder.error(t('Error'), t('Your balance is not sufficient.'));
       return;
     }

--- a/src/hooks/transactionFee/reducer.js
+++ b/src/hooks/transactionFee/reducer.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import { transactions } from '@liskhq/lisk-client';
 import { DEFAULT_MIN_REMAINING_BALANCE } from '../../constants/transactions';
 import { toRawLsk } from '../../utilities/conversions';
 
@@ -39,11 +40,15 @@ const reducer = (state, action) => {
     case actionTypes.setMaxAmount: {
       const balance = action.payload.account?.balance;
       const availableBalance = calculateAvailableBalance(balance);
+      let maxAmount = availableBalance - toRawLsk(action.payload.response.value);
+      if (maxAmount < 0) {
+        maxAmount = 0;
+      }
       const result = {
         ...action.response,
         maxAmount: {
           ...state.maxAmount,
-          value: availableBalance - toRawLsk(action.payload.response.value),
+          value: maxAmount
         },
       };
 

--- a/src/hooks/transactionFee/reducer.js
+++ b/src/hooks/transactionFee/reducer.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-import { transactions } from '@liskhq/lisk-client';
 import { DEFAULT_MIN_REMAINING_BALANCE } from '../../constants/transactions';
 import { toRawLsk } from '../../utilities/conversions';
 

--- a/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
+++ b/src/hooks/transactionFee/useTransactionFeeCalculation.test.js
@@ -57,4 +57,19 @@ describe('useTransactionFeeCalculation', () => {
       balance
     ).toEqual(transactionConstants.DEFAULT_MIN_REMAINING_BALANCE);
   });
+
+  it('should return 0 for maximum balance if user balance is 0.05LSK', async () => {
+    const updatedProps = {
+      ...props,
+      account: {
+        balance: transactionConstants.DEFAULT_MIN_REMAINING_BALANCE
+      }
+    };
+
+    const { result, waitForValueToChange } = renderHook(() =>
+      useTransactionFeeCalculation({ ...updatedProps }));
+
+    await waitForValueToChange(() => result.current.maxAmount.value);
+    expect(Number(result.current.maxAmount.value)).toEqual(0);
+  });
 });


### PR DESCRIPTION
### What was the problem?
This PR resolves #1280 and #1282 

### How was it solved?
- Return 0 when calculation to send maximum value is negative
- Add fee in validation to check if balance is sufficient before sending a transaction

### How was it tested?
iOS Simulator