### PR TITLE
Fix bug of amount check in send amount screen - Closes #1293 #1296

### DIFF
--- a/src/components/screens/tabs/send/amount/__tests__/lsk.test.js
+++ b/src/components/screens/tabs/send/amount/__tests__/lsk.test.js
@@ -149,6 +149,23 @@ test('Should show error message if amount to send is not valid', (done) => {
   });
 });
 
+test('Should show error message if amount to send is empty', (done) => {
+  const { getAllByText, getByTestId } = render(
+    <Provider store={store}>
+      <SendLsk {...mockProps} />
+    </Provider>
+  );
+
+  const submitButton = getByTestId('submit-button');
+  fireEvent.press(submitButton);
+  act(() => {
+    setTimeout(() => {
+      expect(getAllByText('Provide a correct amount of LSK')).toHaveLength(1);
+      done();
+    }, 1000);
+  });
+});
+
 test('Should re-Calculate transaction fee when the amount to send is changed', (done) => {
   const { getAllByText, getByLabelText } = render(
     <Provider store={store}>

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -222,7 +222,8 @@ const AmountLSK = (props) => {
     const { amount, errorMessage } = state;
     if (errorMessage !== '') return;
     const transactionPriority = priority ? priority[selectedPriority] : null;
-    if (Number(amount) + fee.value > Number(fromRawLsk(maxAmount.value))) {
+    if (accounts.info[settings.token.active].balance - toRawLsk(amount) - toRawLsk(fee.value)
+      < transactionConstants.DEFAULT_MIN_REMAINING_BALANCE) {
       DropDownHolder.error(t('Error'), t('Your balance is not sufficient.'));
       return;
     }
@@ -293,7 +294,7 @@ const AmountLSK = (props) => {
         button={{
           title: t('Continue')
         }}
-        disabled={!isPriorityFetched || state.errorMessage}
+        // disabled={!isPriorityFetched || state.errorMessage}
         buttonTestID="submit-button"
       >
         <View>

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -222,6 +222,13 @@ const AmountLSK = (props) => {
     const { amount, errorMessage } = state;
     if (errorMessage !== '') return;
     const transactionPriority = priority ? priority[selectedPriority] : null;
+    if (!amount) {
+      setState(prevState => ({
+        ...prevState,
+        errorMessage: t('Provide a correct amount of LSK')
+      }));
+      return;
+    }
     if (accounts.info[settings.token.active].balance - toRawLsk(amount) - toRawLsk(fee.value)
       < transactionConstants.DEFAULT_MIN_REMAINING_BALANCE) {
       DropDownHolder.error(t('Error'), t('Your balance is not sufficient.'));

--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -294,7 +294,7 @@ const AmountLSK = (props) => {
         button={{
           title: t('Continue')
         }}
-        // disabled={!isPriorityFetched || state.errorMessage}
+        disabled={!isPriorityFetched || state.errorMessage}
         buttonTestID="submit-button"
       >
         <View>


### PR DESCRIPTION
### What was the problem?
This PR resolves #1293 and #1296

### How was it solved?
Refactored check to be account balance - fee - amount < minimum balance account

### How was it tested?
iOS simulator