### PR TITLE
Fix issue with send maximum calculation - Closes #1304

### DIFF
--- a/src/components/screens/tabs/send/amount/lsk.js
+++ b/src/components/screens/tabs/send/amount/lsk.js
@@ -118,7 +118,7 @@ const AmountLSK = (props) => {
     if (isMaximum) {
       onChange(fromRawLsk(maxAmount.value), true);
     }
-  }, [isMaximum, fee.value]);
+  }, [isMaximum, fee.value, maxAmount.value, reference.value]);
 
   const loadInitialData = () => {
     const { sharedData } = props;


### PR DESCRIPTION
### What was the problem?
This PR resolves #1304 

### How was it solved?
Added maxAmount and reference to useEffect to ensure the recalculation based on either of these triggers a change to maximum value amount

### How was it tested?
- iOS Simulator
