### PR TITLE
Introduce useTheme custom hook for app theme consumption - Closes #1400

### DIFF
--- a/src/components/shared/withTheme/index.js
+++ b/src/components/shared/withTheme/index.js
@@ -7,6 +7,7 @@ const getDisplayName = Component =>
   Component.displayName || Component.name || 'Component';
 
 /**
+ * @deprecated - Use useTheme hook instead.
  * React Navigation has a problem with rendering components as
  * route handlers when they're wrapped with React's forwardRef API.
  * Because of this, we need to avoid using refs in them.
@@ -15,7 +16,7 @@ const getDisplayName = Component =>
  * However, it's safe to use refs in child components and forwardRefs flag
  * should be true when wrapping them with this HOC.
  */
-export default (WrappedComponent, styles, forwardRefs = false) => {
+const withTheme = (WrappedComponent, styles, forwardRefs = false) => {
   class WithTheme extends React.Component {
     render() {
       // normalized the forwarded reference
@@ -52,3 +53,5 @@ export default (WrappedComponent, styles, forwardRefs = false) => {
     ))
     : HoistedWithTheme;
 };
+
+export default withTheme;

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+
+import ThemeContext from '../contexts/theme';
+import { createThemedStyles } from '../utilities/helpers';
+
+export function useTheme({ noTheme, styles: baseStyles }) {
+  const theme = useContext(ThemeContext);
+
+  const styles = createThemedStyles(theme, baseStyles, noTheme);
+
+  return { theme, styles };
+}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -3,6 +3,12 @@ import { useContext } from 'react';
 import ThemeContext from '../contexts/theme';
 import { createThemedStyles } from '../utilities/helpers';
 
+/**
+ * Hook for consuming the app theme.
+ * @param {styles} styles - Optional style declarations to be themed.
+ * @param {boolean} noTheme - Flag to disable theme in case of needed.
+ * @returns {Object} - The theme stored by context and the themed styles created based on it.
+ */
 export function useTheme({ noTheme, styles: baseStyles }) {
   const theme = useContext(ThemeContext);
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #1400

### How was it solved?
- Introduce a new custom hook for theme consumption: `useTheme`
- Add docs to deprecate `withTheme` HOC

### How was it tested?
Local environment, importing and using the hook on existing components that where using `withTheme`.