### PR TITLE
Disable to delete default blockchain applications in manage - Closes #1392 

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -370,6 +370,10 @@
         "descriptionText": "Diese Anwendung befindet sich nicht mehr in Ihrer Anwendungsliste.",
         "confirmButtonText": "Jetzt entfernen"
       },
+      "deleteDefaultApplicationModal": {
+        "description": "Die Standardanwendung kann nicht entfernt werden",
+        "buttonText": "Weiter zu Anwendungen"
+      },
       "continueToWalletButtonText": "Weiter zur Geldbörse"
     },
     "explore":{

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -375,6 +375,10 @@
         "descriptionText": "This application will no longer be in your application list.",
         "confirmButtonText": "Remove now"
       },
+      "deleteDefaultApplicationModal": {
+        "description": "The default application can not be removed",
+        "buttonText": "Continue to Applications"
+      },
       "continueToWalletButtonText": "Continue to wallet" 
     },
     "explore":{

--- a/src/assets/svgs/CircleCrossedSvg.js
+++ b/src/assets/svgs/CircleCrossedSvg.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Svg, Path, Circle } from 'react-native-svg';
+
+export default function CircleCrossedSvg({
+  color = '#FF4557',
+  height = 20,
+  width = 20,
+  style
+}) {
+  return (
+    <Svg
+      width={width}
+      height={height}
+      viewBox="0 0 47 47"
+      fill="none"
+      style={style}
+    >
+      <Circle cx="23.5" cy="23.5" r="22.5" stroke={color} strokeWidth="2"/>
+      <Path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M32.4118 16.8472C32.7826 16.4936 32.7826 15.9203 32.4118 15.5667C32.0411 15.2131 31.44 15.2131 31.0693 15.5667L23.6617 22.6317L16.9246 16.2061C16.5538 15.8525 15.9527 15.8525 15.582 16.2061C15.2113 16.5597 15.2113 17.133 15.582 17.4865L22.3192 23.9121L15.582 30.3377C15.2113 30.6913 15.2113 31.2646 15.582 31.6182C15.9527 31.9718 16.5538 31.9718 16.9246 31.6182L23.6617 25.1926L31.0693 32.2576C31.44 32.6112 32.0411 32.6112 32.4118 32.2576C32.7826 31.904 32.7826 31.3307 32.4118 30.9771L25.0043 23.9121L32.4118 16.8472Z"
+        fill={color}
+      />
+    </Svg>
+  );
+}

--- a/src/components/screens/ErrorScreen/index.js
+++ b/src/components/screens/ErrorScreen/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+import { useTheme } from 'hooks/useTheme';
+import { PrimaryButton } from 'components/shared/toolBox/button';
+import CircleCrossedSvg from 'assets/svgs/CircleCrossedSvg';
+
+import getErrorScreenStyles from './styles';
+
+export default function ErrorScreen({
+  title,
+  description,
+  styles: baseStyles,
+  onContinue,
+  buttonText,
+  children,
+  disabled,
+}) {
+  const { styles } = useTheme({
+    styles: getErrorScreenStyles(),
+  });
+
+  return (
+    <View style={[styles.wrapper, styles.theme.wrapper, baseStyles?.wrapper]}>
+      <View style={[styles.container]}>
+        <View style={styles.illustration}>
+
+        <CircleCrossedSvg height={48} width={48}/>
+
+        </View>
+
+        {title && (
+            <Text style={[styles.title, styles.theme.title, baseStyles?.title]}>
+              {title}
+            </Text>
+        )}
+
+        {description && (
+          <Text style={[styles.description, styles.theme.description, baseStyles?.description]}>
+            {description}
+          </Text>
+        )}
+
+        {children}
+      </View>
+
+      <PrimaryButton
+        noTheme
+        title={buttonText}
+        style={[styles.continueButton, baseStyles?.continueButton]}
+        onPress={onContinue}
+        disabled={disabled}
+      />
+    </View>
+
+  );
+}

--- a/src/components/screens/ErrorScreen/index.js
+++ b/src/components/screens/ErrorScreen/index.js
@@ -25,14 +25,14 @@ export default function ErrorScreen({
       <View style={[styles.container]}>
         <View style={styles.illustration}>
 
-        <CircleCrossedSvg height={48} width={48}/>
+        <CircleCrossedSvg height={48} width={48} style={[styles.icon]}/>
 
         </View>
 
         {title && (
-            <Text style={[styles.title, styles.theme.title, baseStyles?.title]}>
-              {title}
-            </Text>
+          <Text style={[styles.title, styles.theme.title, baseStyles?.title]}>
+            {title}
+          </Text>
         )}
 
         {description && (

--- a/src/components/screens/ErrorScreen/styles.js
+++ b/src/components/screens/ErrorScreen/styles.js
@@ -1,0 +1,71 @@
+import {
+  themes, colors, boxes, fonts
+} from 'constants/styleGuide';
+
+export default function getErrorScreenStyles() {
+  return {
+    common: {
+      wrapper: {
+        flex: 1,
+        padding: boxes.boxPadding,
+        marginVertical: boxes.boxPadding
+      },
+      container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center'
+      },
+      avatarContainer: {
+        alignItems: 'center',
+      },
+      address: {
+        marginTop: 10,
+        textAlign: 'center',
+        color: colors.light.blueGray,
+        fontSize: fonts.size.small
+      },
+      illustration: {
+        paddingVertical: 30
+      },
+      title: {
+        fontFamily: fonts.family.heading,
+        fontSize: fonts.size.h3,
+        padding: 5,
+        textAlign: 'center',
+      },
+      description: {
+        fontFamily: fonts.family.context,
+        fontSize: fonts.size.base,
+        textAlign: 'center',
+        padding: 10
+      },
+      continueButton: {
+        paddingHorizontal: 20
+      }
+    },
+
+    [themes.light]: {
+      wrapper: {
+        backgroundColor: colors.light.white,
+      },
+      title: {
+        color: colors.light.zodiacBlue,
+      },
+      description: {
+        color: colors.light.zodiacBlue,
+      },
+    },
+
+    [themes.dark]: {
+      wrapper: {
+        backgroundColor: colors.dark.mainBg,
+      },
+      title: {
+        color: colors.dark.ghost,
+      },
+      description: {
+        color: colors.dark.ghost,
+      },
+    }
+  };
+}

--- a/src/components/screens/ErrorScreen/styles.js
+++ b/src/components/screens/ErrorScreen/styles.js
@@ -15,17 +15,8 @@ export default function getErrorScreenStyles() {
         alignItems: 'center',
         justifyContent: 'center'
       },
-      avatarContainer: {
-        alignItems: 'center',
-      },
-      address: {
-        marginTop: 10,
-        textAlign: 'center',
-        color: colors.light.blueGray,
-        fontSize: fonts.size.small
-      },
-      illustration: {
-        paddingVertical: 30
+      icon: {
+        marginBottom: 16,
       },
       title: {
         fontFamily: fonts.family.heading,
@@ -37,10 +28,11 @@ export default function getErrorScreenStyles() {
         fontFamily: fonts.family.context,
         fontSize: fonts.size.base,
         textAlign: 'center',
-        padding: 10
+        padding: 8,
+        marginBottom: 0,
       },
       continueButton: {
-        paddingHorizontal: 20
+        paddingHorizontal: 24
       }
     },
 

--- a/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
@@ -34,16 +34,18 @@ export function useBlockchainApplicationRowActions({
       break;
 
     case 'manage':
-      rightActions = [
-        {
-          title: t('application.explore.applicationList.deleteText'),
-          color: colors.light.furyRed,
-          icon: () => <DeleteSvg color={colors.light.white} />,
-          onPress: () => {
-            navigation.navigate('DeleteApplication', { application });
+      if (!application.isDefault) {
+        rightActions = [
+          {
+            title: t('application.explore.applicationList.deleteText'),
+            color: colors.light.furyRed,
+            icon: () => <DeleteSvg color={colors.light.white} />,
+            onPress: () => {
+              navigation.navigate('DeleteApplication', { application });
+            },
           },
-        },
-      ];
+        ];
+      }
       break;
 
     default:

--- a/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
@@ -11,7 +11,7 @@ export function useBlockchainApplicationRowActions({
   application,
   variant,
   navigation,
-  setShowCannotDeleteDefaultApplicationModal
+  setShowDeleteDefaultApplicationModal
 }) {
   const { togglePin } = usePinBlockchainApplication();
 
@@ -46,7 +46,7 @@ export function useBlockchainApplicationRowActions({
           icon: () => <DeleteSvg color={colors.light.white} />,
           onPress: () => {
             if (application.isDefault) {
-              setShowCannotDeleteDefaultApplicationModal(true);
+              setShowDeleteDefaultApplicationModal(true);
             } else {
               navigation.navigate('DeleteApplication', { application });
             }

--- a/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/hooks.js
@@ -7,7 +7,11 @@ import DeleteSvg from 'assets/svgs/DeleteSvg';
 import { usePinBlockchainApplication } from '../../hooks/usePinBlockchainApplication';
 
 export function useBlockchainApplicationRowActions({
-  t, application, variant, navigation
+  t,
+  application,
+  variant,
+  navigation,
+  setShowCannotDeleteDefaultApplicationModal
 }) {
   const { togglePin } = usePinBlockchainApplication();
 
@@ -34,18 +38,22 @@ export function useBlockchainApplicationRowActions({
       break;
 
     case 'manage':
-      if (!application.isDefault) {
-        rightActions = [
-          {
-            title: t('application.explore.applicationList.deleteText'),
-            color: colors.light.furyRed,
-            icon: () => <DeleteSvg color={colors.light.white} />,
-            onPress: () => {
+
+      rightActions = [
+        {
+          title: t('application.explore.applicationList.deleteText'),
+          color: colors.light.furyRed,
+          icon: () => <DeleteSvg color={colors.light.white} />,
+          onPress: () => {
+            if (application.isDefault) {
+              setShowCannotDeleteDefaultApplicationModal(true);
+            } else {
               navigation.navigate('DeleteApplication', { application });
-            },
+            }
           },
-        ];
-      }
+        },
+      ];
+
       break;
 
     default:

--- a/src/modules/BlockchainApplication/components/ApplicationRow/index.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/index.js
@@ -97,8 +97,8 @@ function BlockchainApplicationRow({
         coverScreen
       >
         <ErrorScreen
-          description="The default application can not be removed"
-          buttonText="Continue to Applications"
+          description={t('application.manage.deleteDefaultApplicationModal.description')}
+          buttonText={t('application.manage.deleteDefaultApplicationModal.buttonText')}
           onContinue={() => setShowDeleteDefaultApplicationModal(false)}
         />
 

--- a/src/modules/BlockchainApplication/components/ApplicationRow/index.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/index.js
@@ -50,8 +50,6 @@ function BlockchainApplicationRow({
     setShowDeleteDefaultApplicationModal
   });
 
-  console.log({ showDeleteDefaultApplicationModal });
-
   return (
     <>
       <Swipeable key={application.chainID} leftActions={leftActions} rightActions={rightActions}>
@@ -76,7 +74,7 @@ function BlockchainApplicationRow({
               />
             )}
             {showActive && currentApplication.chainID === application.chainID && (
-              <View style={styles.icon}>
+              <View style={{ marginRight: 12 }}>
                 <CircleCheckedSvg variant="fill" />
               </View>
             )}

--- a/src/modules/BlockchainApplication/components/ApplicationRow/index.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/index.js
@@ -35,8 +35,8 @@ function BlockchainApplicationRow({
   navigation,
 }) {
   const [
-    showCannotDeleteDefaultApplicationModal,
-    setShowCannotDeleteDefaultApplicationModal
+    showDeleteDefaultApplicationModal,
+    setShowDeleteDefaultApplicationModal
   ] = useState(false);
 
   const { theme, styles } = useTheme({ styles: getBlockchainApplicationRowStyles() });
@@ -47,60 +47,61 @@ function BlockchainApplicationRow({
     application,
     variant,
     navigation,
-    setShowCannotDeleteDefaultApplicationModal
+    setShowDeleteDefaultApplicationModal
   });
 
-  console.log({ showCannotDeleteDefaultApplicationModal });
+  console.log({ showDeleteDefaultApplicationModal });
 
   return (
     <>
-    <Swipeable key={application.chainID} leftActions={leftActions} rightActions={rightActions}>
-      <TouchableOpacity style={styles.applicationContainer} onPress={onPress}>
-        <View style={styles.applicationNameContainer}>
-          <Image
-            source={{ uri: application.images.logo.png }}
-            style={{ ...styles.applicationLogoImage }}
-          />
-
-          <P style={[styles.applicationNameLabel, styles.theme.applicationNameLabel]}>
-            {application.name}
-          </P>
-        </View>
-
-        <View style={styles.applicationNameContainer}>
-          {application.isPinned && (
-            <PinSvg
-              color={colors.light.ultramarineBlue}
-              style={{ marginRight: 12 }}
-              variant="fill"
+      <Swipeable key={application.chainID} leftActions={leftActions} rightActions={rightActions}>
+        <TouchableOpacity style={styles.applicationContainer} onPress={onPress}>
+          <View style={styles.applicationNameContainer}>
+            <Image
+              source={{ uri: application.images.logo.png }}
+              style={{ ...styles.applicationLogoImage }}
             />
-          )}
-          {showActive && currentApplication.chainID === application.chainID && (
-            <View style={styles.icon}>
-              <CircleCheckedSvg variant="fill" />
-            </View>
-          )}
 
-          {showCaret && (
-            <CaretSvg
-              direction="right"
-              color={theme === themes.light ? colors.light.zodiacBlue : colors.dark.white}
-            />
-          )}
-        </View>
-      </TouchableOpacity>
-    </Swipeable>
+            <P style={[styles.applicationNameLabel, styles.theme.applicationNameLabel]}>
+              {application.name}
+            </P>
+          </View>
 
-    <ModalBox
+          <View style={styles.applicationNameContainer}>
+            {application.isPinned && (
+              <PinSvg
+                color={colors.light.ultramarineBlue}
+                style={{ marginRight: 12 }}
+                variant="fill"
+              />
+            )}
+            {showActive && currentApplication.chainID === application.chainID && (
+              <View style={styles.icon}>
+                <CircleCheckedSvg variant="fill" />
+              </View>
+            )}
+
+            {showCaret && (
+              <CaretSvg
+                direction="right"
+                color={theme === themes.light ? colors.light.zodiacBlue : colors.dark.white}
+              />
+            )}
+          </View>
+        </TouchableOpacity>
+      </Swipeable>
+
+      <ModalBox
         position="bottom"
-        style={styles.statsModal}
-        isOpen={showCannotDeleteDefaultApplicationModal}
-        onClosed={() => setShowCannotDeleteDefaultApplicationModal(false)}
+        style={styles.deleteDefaultApplicationModal}
+        isOpen={showDeleteDefaultApplicationModal}
+        onClosed={() => setShowDeleteDefaultApplicationModal(false)}
+        coverScreen
       >
         <ErrorScreen
           description="The default application can not be removed"
           buttonText="Continue to Applications"
-          onContinue={() => setShowCannotDeleteDefaultApplicationModal(false)}
+          onContinue={() => setShowDeleteDefaultApplicationModal(false)}
         />
 
       </ModalBox>

--- a/src/modules/BlockchainApplication/components/ApplicationRow/index.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Image, TouchableOpacity } from 'react-native';
+import ModalBox from 'react-native-modalbox';
 import { translate } from 'react-i18next';
 
 import { useTheme } from 'hooks/useTheme';
@@ -9,6 +10,7 @@ import Swipeable from 'components/shared/Swipeable';
 import PinSvg from 'assets/svgs/PinSvg';
 import CaretSvg from 'assets/svgs/CaretSvg';
 import CircleCheckedSvg from 'assets/svgs/CircleCheckedSvg';
+import ErrorScreen from 'components/screens/ErrorScreen';
 import { useCurrentBlockchainApplication } from '../../hooks/useCurrentBlockchainApplication';
 
 import { useBlockchainApplicationRowActions } from './hooks';
@@ -32,6 +34,11 @@ function BlockchainApplicationRow({
   showCaret,
   navigation,
 }) {
+  const [
+    showCannotDeleteDefaultApplicationModal,
+    setShowCannotDeleteDefaultApplicationModal
+  ] = useState(false);
+
   const { theme, styles } = useTheme({ styles: getBlockchainApplicationRowStyles() });
   const [currentApplication] = useCurrentBlockchainApplication();
 
@@ -40,9 +47,13 @@ function BlockchainApplicationRow({
     application,
     variant,
     navigation,
+    setShowCannotDeleteDefaultApplicationModal
   });
 
+  console.log({ showCannotDeleteDefaultApplicationModal });
+
   return (
+    <>
     <Swipeable key={application.chainID} leftActions={leftActions} rightActions={rightActions}>
       <TouchableOpacity style={styles.applicationContainer} onPress={onPress}>
         <View style={styles.applicationNameContainer}>
@@ -79,6 +90,21 @@ function BlockchainApplicationRow({
         </View>
       </TouchableOpacity>
     </Swipeable>
+
+    <ModalBox
+        position="bottom"
+        style={styles.statsModal}
+        isOpen={showCannotDeleteDefaultApplicationModal}
+        onClosed={() => setShowCannotDeleteDefaultApplicationModal(false)}
+      >
+        <ErrorScreen
+          description="The default application can not be removed"
+          buttonText="Continue to Applications"
+          onContinue={() => setShowCannotDeleteDefaultApplicationModal(false)}
+        />
+
+      </ModalBox>
+    </>
   );
 }
 

--- a/src/modules/BlockchainApplication/components/ApplicationRow/styles.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/styles.js
@@ -1,5 +1,5 @@
 import {
-  themes, colors, boxes, fonts
+  themes, colors, fonts
 } from 'constants/styleGuide';
 
 export default function getBlockchainApplicationRowStyles() {
@@ -8,12 +8,6 @@ export default function getBlockchainApplicationRowStyles() {
       container: {
         flexDirection: 'column',
         flex: 1,
-      },
-      listContainer: {
-        flex: 1,
-        flexDirection: 'column',
-        justifyContent: 'center',
-        padding: boxes.boxPadding,
       },
       applicationContainer: {
         flexDirection: 'row',
@@ -42,38 +36,15 @@ export default function getBlockchainApplicationRowStyles() {
         marginRight: 15,
         fontWeight: '600',
       },
-      searchContainer: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        width: '100%',
-        marginTop: 32,
-      },
-      searchIcon: {
-        position: 'absolute',
-        zIndex: 1,
-        left: 30,
-      },
-      input: {
-        flexWrap: 'wrap',
-        paddingLeft: 36,
-        paddingBottom: 8,
-        paddingTop: 8,
-        fontFamily: fonts.family.context,
-        borderRadius: 26,
-        borderWidth: 1,
-        borderColor: colors.light.platinumGray,
-      },
-      inputContainer: {
-        marginTop: -20,
-        position: 'relative',
-      },
-      statsModal: {
-        height: 500,
-        zIndex: 2,
+      deleteDefaultApplicationModal: {
+
+        backgroundColor: colors.light.white,
+        height: 300,
+        zIndex: 3,
         borderTopLeftRadius: 24,
         borderTopRightRadius: 24,
       },
-      statsModalCloseButton: {
+      deleteDefaultApplicationModalCloseButton: {
         position: 'absolute',
         right: 12,
         top: 24,

--- a/src/modules/BlockchainApplication/components/ApplicationRow/styles.js
+++ b/src/modules/BlockchainApplication/components/ApplicationRow/styles.js
@@ -37,18 +37,11 @@ export default function getBlockchainApplicationRowStyles() {
         fontWeight: '600',
       },
       deleteDefaultApplicationModal: {
-
         backgroundColor: colors.light.white,
-        height: 300,
+        height: 280,
         zIndex: 3,
         borderTopLeftRadius: 24,
         borderTopRightRadius: 24,
-      },
-      deleteDefaultApplicationModalCloseButton: {
-        position: 'absolute',
-        right: 12,
-        top: 24,
-        zIndex: 1,
       },
     },
     [themes.light]: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1392

### How was it solved?
- [x]  Hide the "delete" swippable button for default applications to prevent its deletion (manage blockchain applications feature)

### How was it tested?
Locally, on iOS Simulator.
