### PR TITLE
Fix Download Passphrase Screen gets skipped on first load

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -332,19 +332,21 @@
       "restore_file": "Aus Datei wiederherstellen",
       "downloaded": "Heruntergeladen!",
       "buttons": {
-        "passwordSetupContinue": "Weiter zu Dashboard",
-        "saveAccount": "Konto speichern",
-        "download": "Heruntergeladen"
+        "passwordSetupContinueButton": "Weiter zu Dashboard",
+        "saveAccountButton": "Konto speichern"
       }
     },
     "form": {
-      "enterPassword": "Passwort eingeben",
-      "confirmPassword": "Bestätigen Sie Ihr Passwort",
-      "accountName": "Kontoname (optional)",
-      "passwordSetupContinue": "Weiter zu Dashboard",
+      "passwordLabel": "Passwort eingeben",
+      "confirmPasswordLabel": "Bestätigen Sie Ihr Passwort",
+      "accountNameLabel": "Kontoname (optional)",
+      "passwordSetupContinueButton": "Weiter zu Dashboard",
+      "termsAgreementText": "Ich stimme zu, meine verschlüsselte geheime Wiederherstellungsphrase auf diesem Gerät zu speichern",
       "errors": {
-        "passwordError": "Das Passwort muss 8 Zeichen enthalten, einen Großbuchstaben, einen Kleinbuchstaben, eine Zahl und ein Sonderzeichen",
-        "confirmPasswordError": "Bestätigen Sie, dass die Passwörter übereinstimmen"
+        "noEmptyPasswordError": "Das Passwort muss einen Wert haben",
+        "noEmptyConfirmPasswordError": "Passwort bestätigen muss einen Wert haben",
+        "passwordRequirementsError": "Das Passwort muss 8 Zeichen enthalten, einen Großbuchstaben, einen Kleinbuchstaben, eine Zahl und einen Sonderbuchstaben",
+        "passwordsDontMatchError": "Bestätigen Sie, dass die Passwörter übereinstimmen"
       }
     }
   },

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -332,19 +332,21 @@
       "restore_file": "Restore from file",
       "downloaded": "Downloaded!",
       "buttons": {
-        "passwordSetupContinue": "Continue to Dashboard",
-        "saveAccount": "Save account",
-        "download": "Download"
+        "passwordSetupContinueButton": "Continue to Dashboard",
+        "saveAccountButton": "Save account"
       }
     },
     "form": {
-      "enterPassword": "Enter password",
-      "confirmPassword": "Confirm your password",
-      "accountName": "Account name (optional)",
-      "passwordSetupContinue": "Continue to Dashboard",
+      "passwordLabel": "Enter password",
+      "confirmPasswordLabel": "Confirm your password",
+      "accountNameLabel": "Account name (optional)",
+      "passwordSetupContinueButton": "Continue to Dashboard",
+      "termsAgreementText": "I agree to store my encrypted secret recovery phrase on this device",
       "errors": {
-        "passwordError": "Must Contain 8 Characters, One Uppercase, One Lowercase, One Number and One Special Case Character",
-        "confirmPasswordError": "Confirm that passwords match"
+        "noEmptyPasswordError": "Password must have a value",
+        "noEmptyConfirmPasswordError": "Confirm password must have a value",
+        "passwordRequirementsError": "Password must contain 8 characters, one uppercase, one lowercase, one number and one special case character",
+        "passwordsDontMatchError": "Confirm that passwords match"
       }
     }
   },

--- a/src/modules/Auth/PasswordSetupForm/index.js
+++ b/src/modules/Auth/PasswordSetupForm/index.js
@@ -29,7 +29,7 @@ export default function PasswordSetupForm({ route }) {
       isAgreedField,
       formState,
     },
-    { encryptedAccount, isLoading, isSuccess, isError },
+    { encryptedAccount, isLoading, isSuccess },
   ] = usePasswordSetupForm(passphrase);
 
   const { styles } = useTheme({ styles: getStyles() });
@@ -57,7 +57,7 @@ export default function PasswordSetupForm({ route }) {
               testID="enter-password"
               value={passwordField.value}
               onChange={passwordField.onChange}
-              label={i18next.t('auth.form.enterPassword')}
+              label={i18next.t('auth.form.passwordLabel')}
               secureTextEntry
               innerStyles={{
                 containerStyle: styles.inputContainer,
@@ -70,7 +70,7 @@ export default function PasswordSetupForm({ route }) {
               testID="confirm-password"
               value={confirmPasswordField.value}
               onChange={confirmPasswordField.onChange}
-              label={i18next.t('auth.form.confirmPassword')}
+              label={i18next.t('auth.form.confirmPasswordLabel')}
               secureTextEntry
               innerStyles={{
                 containerStyle: styles.inputContainer,
@@ -83,7 +83,7 @@ export default function PasswordSetupForm({ route }) {
               testID="account-name"
               value={accountNameField.value}
               onChange={accountNameField.onChange}
-              label={i18next.t('auth.form.accountName')}
+              label={i18next.t('auth.form.accountNameLabel')}
               innerStyles={{
                 containerStyle: styles.inputContainer,
                 input: styles.input,
@@ -100,16 +100,14 @@ export default function PasswordSetupForm({ route }) {
               </View>
 
               <Text style={[styles.actionText, styles.theme.description]}>
-                I agree to store my encrypted secret recovery phrase on this device
+                {i18next.t('auth.form.termsAgreementText')}
               </Text>
             </View>
           </ScrollView>
 
           <View style={[styles.footer]}>
-            {isError && <Text>Error saving your account. Please try again.</Text>}
-
             <PrimaryButton onPress={handleSubmit} disabled={!isAgreedField.value || isLoading}>
-              {isLoading ? 'Loading...' : i18next.t('auth.setup.buttons.saveAccount')}
+              {isLoading ? 'Loading...' : i18next.t('auth.setup.buttons.saveAccountButton')}
             </PrimaryButton>
           </View>
         </>

--- a/src/modules/Auth/PasswordSetupForm/index.js
+++ b/src/modules/Auth/PasswordSetupForm/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Text, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -10,71 +10,36 @@ import HeaderBackButton from 'components/navigation/headerBackButton';
 import Input from 'components/shared/toolBox/input';
 import { PrimaryButton } from 'components/shared/toolBox/button';
 import colors from 'constants/styleGuide/colors';
-import DropDownHolder from 'utilities/alert';
-import { useAccounts } from 'modules/Accounts/hooks/useAccounts';
-import { useCurrentAccount } from 'modules/Accounts/hooks/useCurrentAccount';
-import { passwordValidator } from '../validators';
 import PasswordSetupSuccess from '../PasswordSetupSuccess';
-import { useEncryptAccount } from '../hooks/useEncryptAccount';
 
 import getStyles from './styles';
+import { usePasswordSetupForm } from '../hooks/usePasswordSetupForm';
 
-// eslint-disable-next-line max-statements
 export default function PasswordSetupForm({ route }) {
   const navigation = useNavigation();
 
-  const { encryptAccount } = useEncryptAccount();
-  const { setAccount } = useAccounts();
-  const [, setCurrentAccount] = useCurrentAccount();
   const { passphrase } = route.params;
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [accountName, setAccountName] = useState('');
-  const [isAgreed, setIsAgreed] = useState(false);
-  const [passwordError, setPasswordError] = useState('');
-  const [confirmPasswordError, setConfirmPasswordError] = useState('');
-  const [isSuccess, setIsSuccess] = useState(false);
-  const [encryptedJSON, setEncryptedJSON] = useState();
+
+  const [
+    {
+      handleSubmit,
+      passwordField,
+      confirmPasswordField,
+      accountNameField,
+      isAgreedField,
+      formState,
+    },
+    { encryptedAccount, isLoading, isSuccess, isError },
+  ] = usePasswordSetupForm(passphrase);
 
   const { styles } = useTheme({ styles: getStyles() });
 
-  // eslint-disable-next-line max-statements, consistent-return
-  const handleSubmit = async () => {
-    try {
-      if (!passwordValidator(password)) {
-        return setPasswordError('auth.form.errors.passwordError');
-      }
-      if (password !== confirmPassword) {
-        return setConfirmPasswordError('auth.form.errors.confirmPasswordError');
-      }
-      const data = await encryptAccount({
-        recoveryPhrase: passphrase,
-        password,
-        name: accountName,
-      });
-      setEncryptedJSON(data);
-      setIsSuccess(true);
-      setAccount(data);
-      setCurrentAccount(data);
-    } catch (error) {
-      return DropDownHolder.error(
-        i18next.t('Error'),
-        i18next.t('auth.setup.decryptPassphraseError')
-      );
-    }
-  };
-
-  useEffect(() => {
-    setPasswordError('');
-    setConfirmPasswordError('');
-  }, [password, confirmPassword]);
-
-  const onContinue = () => navigation.navigate('Main');
+  const handleContinue = () => navigation.navigate('Main');
 
   return (
     <SafeAreaView style={[styles.wrapper, styles.theme.wrapper]}>
       {isSuccess ? (
-        <PasswordSetupSuccess encryptedJson={encryptedJSON} onContinue={onContinue} />
+        <PasswordSetupSuccess encryptedJson={encryptedAccount} onContinue={handleContinue} />
       ) : (
         <>
           <HeaderBackButton
@@ -90,46 +55,46 @@ export default function PasswordSetupForm({ route }) {
 
             <Input
               testID="enter-password"
+              value={passwordField.value}
+              onChange={passwordField.onChange}
+              label={i18next.t('auth.form.enterPassword')}
+              secureTextEntry
               innerStyles={{
                 containerStyle: styles.inputContainer,
                 input: styles.input,
               }}
-              label={i18next.t('auth.form.enterPassword')}
-              secureTextEntry
-              onChange={setPassword}
-              value={password}
-              error={passwordError && i18next.t(passwordError)}
+              error={formState.errors?.password?.message}
             />
 
             <Input
               testID="confirm-password"
+              value={confirmPasswordField.value}
+              onChange={confirmPasswordField.onChange}
+              label={i18next.t('auth.form.confirmPassword')}
+              secureTextEntry
               innerStyles={{
                 containerStyle: styles.inputContainer,
                 input: styles.input,
               }}
-              label={i18next.t('auth.form.confirmPassword')}
-              secureTextEntry
-              onChange={setConfirmPassword}
-              value={confirmPassword}
-              error={confirmPasswordError && i18next.t(confirmPasswordError)}
+              error={formState.errors?.confirmPassword?.message}
             />
 
             <Input
               testID="account-name"
+              value={accountNameField.value}
+              onChange={accountNameField.onChange}
+              label={i18next.t('auth.form.accountName')}
               innerStyles={{
                 containerStyle: styles.inputContainer,
                 input: styles.input,
               }}
-              label={i18next.t('auth.form.accountName')}
-              onChange={setAccountName}
-              value={accountName}
             />
 
             <View style={styles.actionContainer}>
               <View style={styles.switch}>
                 <Switch
-                  value={isAgreed}
-                  onValueChange={setIsAgreed}
+                  value={isAgreedField.value}
+                  onValueChange={(value) => isAgreedField.onChange(value)}
                   trackColor={{ true: colors.light.ultramarineBlue }}
                 />
               </View>
@@ -141,11 +106,11 @@ export default function PasswordSetupForm({ route }) {
           </ScrollView>
 
           <View style={[styles.footer]}>
-            <PrimaryButton
-              title={i18next.t('auth.setup.buttons.saveAccount')}
-              onPress={handleSubmit}
-              disabled={!isAgreed}
-            />
+            {isError && <Text>Error saving your account. Please try again.</Text>}
+
+            <PrimaryButton onPress={handleSubmit} disabled={!isAgreedField.value || isLoading}>
+              {isLoading ? 'Loading...' : i18next.t('auth.setup.buttons.saveAccount')}
+            </PrimaryButton>
           </View>
         </>
       )}

--- a/src/modules/Auth/PasswordSetupSuccess/index.js
+++ b/src/modules/Auth/PasswordSetupSuccess/index.js
@@ -21,7 +21,7 @@ export default function PasswordSetupSuccess({ encryptedJson, onContinue }) {
       illustration={<CompletedIllustrationSvg />}
       title={i18next.t('auth.setup.passwordSetupSuccessTitle')}
       description={i18next.t('auth.setup.passwordSetupSuccessDescription')}
-      buttonText={i18next.t('auth.setup.buttons.passwordSetupContinue')}
+      buttonText={i18next.t('auth.setup.buttons.passwordSetupContinueButton')}
       disabled={!isSuccessDownloadFile}
       onContinue={onContinue}
     >

--- a/src/modules/Auth/components/PasswordForm/index.js
+++ b/src/modules/Auth/components/PasswordForm/index.js
@@ -23,7 +23,7 @@ export default function PasswordForm({ address, onPress, testID, theme, onSubmit
         <P style={[styles.address, styles.theme.address]}>{address}</P>
 
         <Input
-          placeholder={i18next.t('auth.form.enterPassword')}
+          placeholder={i18next.t('auth.form.passwordLabel')}
           autoCorrect={false}
           autoFocus
           placeholderTextColor={

--- a/src/modules/Auth/hooks/usePasswordSetupForm.js
+++ b/src/modules/Auth/hooks/usePasswordSetupForm.js
@@ -26,6 +26,12 @@ const validationSchema = yup
   })
   .required();
 
+/**
+ * Provides a stateful form to handle users passwords setup process.
+ * @param {String} passphrase - Generated passphrase to consider on the submit.
+ * @returns - The form fields, error state, submit callback and other handlers.
+ * Also, the encrypt process state (isLoading, isError, isSuccess, among others).
+ */
 export function usePasswordSetupForm(passphrase) {
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState();

--- a/src/modules/Auth/hooks/usePasswordSetupForm.js
+++ b/src/modules/Auth/hooks/usePasswordSetupForm.js
@@ -16,13 +16,13 @@ const validationSchema = yup
   .shape({
     password: yup
       .string()
-      .required('Password must have a value.')
-      .matches(passwordValidationRegex, 'Password must match min requirements'),
+      .required(i18next.t('auth.form.errors.noEmptyPasswordError'))
+      .matches(passwordValidationRegex, i18next.t('auth.form.errors.passwordRequirementsError')),
     confirmPassword: yup
       .string()
-      .required('Confirm password must have a value.')
-      .matches(passwordValidationRegex, 'Password must match min requirements')
-      .oneOf([yup.ref('password'), null], 'Passwords must match'),
+      .required(i18next.t('auth.form.errors.noEmptyConfirmPasswordError'))
+      .matches(passwordValidationRegex, i18next.t('auth.form.errors.passwordRequirementsError'))
+      .oneOf([yup.ref('password'), null], i18next.t('auth.form.errors.passwordsDontMatchError')),
   })
   .required();
 

--- a/src/modules/Auth/hooks/usePasswordSetupForm.js
+++ b/src/modules/Auth/hooks/usePasswordSetupForm.js
@@ -1,0 +1,127 @@
+/* eslint-disable max-statements */
+import { useCallback, useState } from 'react';
+import { useForm, useController } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import i18next from 'i18next';
+
+import DropDownHolder from 'utilities/alert';
+import { passwordValidationRegex } from 'modules/Auth/validators';
+import { useAccounts } from 'modules/Accounts/hooks/useAccounts';
+import { useCurrentAccount } from 'modules/Accounts/hooks/useCurrentAccount';
+import { useEncryptAccount } from './useEncryptAccount';
+
+const validationSchema = yup
+  .object()
+  .shape({
+    password: yup
+      .string()
+      .required('Password must have a value.')
+      .matches(passwordValidationRegex, 'Password must match min requirements'),
+    confirmPassword: yup
+      .string()
+      .required('Confirm password must have a value.')
+      .matches(passwordValidationRegex, 'Password must match min requirements')
+      .oneOf([yup.ref('password'), null], 'Passwords must match'),
+  })
+  .required();
+
+export function usePasswordSetupForm(passphrase) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState();
+  const [isError, setIsError] = useState();
+  const [error, setError] = useState();
+  const [encryptedAccount, setEncryptedAccount] = useState();
+
+  const { setAccount } = useAccounts();
+  const [, setCurrentAccount] = useCurrentAccount();
+  const { encryptAccount } = useEncryptAccount();
+
+  const resetState = useCallback(() => {
+    if (isSuccess !== undefined) {
+      setIsSuccess();
+    }
+    if (isError !== undefined) {
+      setIsError();
+    }
+    if (error !== undefined) {
+      setError();
+    }
+  }, [error, isError, isSuccess]);
+
+  const { handleSubmit: baseHandleSubmit, ...form } = useForm({
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+      accountName: '',
+      isAgreed: false,
+    },
+    resolver: yupResolver(validationSchema),
+  });
+
+  const handleSubmit = baseHandleSubmit(async (values) => {
+    try {
+      resetState();
+
+      setIsLoading(true);
+
+      const data = await encryptAccount({
+        recoveryPhrase: passphrase,
+        password: values.password,
+        name: values.accountName,
+      });
+
+      setEncryptedAccount(data);
+      setAccount(data);
+      setCurrentAccount(data);
+
+      setIsLoading(false);
+      setIsSuccess(true);
+    } catch (_error) {
+      setIsLoading(false);
+      setIsSuccess(false);
+      setError(_error);
+      setIsError(true);
+
+      DropDownHolder.error(i18next.t('Error'), i18next.t('auth.setup.decryptPassphraseError'));
+    }
+  });
+
+  const { field: passwordField } = useController({
+    name: 'password',
+    control: form.control,
+  });
+
+  const { field: confirmPasswordField } = useController({
+    name: 'confirmPassword',
+    control: form.control,
+  });
+
+  const { field: accountNameField } = useController({
+    name: 'accountName',
+    control: form.control,
+  });
+
+  const { field: isAgreedField } = useController({
+    name: 'isAgreed',
+    control: form.control,
+  });
+
+  return [
+    {
+      ...form,
+      handleSubmit,
+      passwordField,
+      confirmPasswordField,
+      accountNameField,
+      isAgreedField,
+    },
+    {
+      encryptedAccount,
+      isLoading,
+      isSuccess,
+      isError,
+      error,
+    },
+  ];
+}


### PR DESCRIPTION
### What was the problem?

This PR resolves #1543

### How was it solved?

Introduce new `usePasswordSetupForm` for pw setup process, which handles properly the async process of encrypting the account and transitioning to the JSON download screen without any issue.

Also, introduces a more clean a scalable business logic for the process.

### How was it tested?

iOS and Android simulators.