### PR TITLE
Fix Send Token form don't setup the default token on `Transaction` object

### DIFF
--- a/src/modules/SendToken/components/SummaryStep/index.js
+++ b/src/modules/SendToken/components/SummaryStep/index.js
@@ -10,6 +10,7 @@ import { SignTransaction } from 'modules/Transactions/components/SignTransaction
 import { useTransactionSummary } from 'modules/Transactions/components/TransactionSummary/hooks';
 import { PrimaryButton, Button } from 'components/shared/toolBox/button';
 import BottomModal from 'components/shared/BottomModal';
+import { getDryRunTransactionError } from '../../../Transactions/utils/helpers';
 
 import getSendTokenSummaryStepStyles from './styles';
 
@@ -43,6 +44,13 @@ export default function SendTokenSummaryStep({ form, prevStep, reset, transactio
   const { styles } = useTheme({
     styles: getSendTokenSummaryStepStyles(),
   });
+
+  const broadcastTransactionError = form.broadcastTransactionMutation.error;
+
+  const dryRunTransactionError =
+    form.dryRunTransactionMutation.error ||
+    (form.dryRunTransactionMutation.data?.data &&
+      getDryRunTransactionError(form.dryRunTransactionMutation.data.data));
 
   return (
     <>
@@ -82,8 +90,10 @@ export default function SendTokenSummaryStep({ form, prevStep, reset, transactio
           amount={summary.amount}
           token={summary.token}
           isSuccess={form.broadcastTransactionMutation.isSuccess}
-          isLoading={form.broadcastTransactionMutation.isLoading}
-          error={form.broadcastTransactionMutation.error || form.dryRunTransactionMutation.error}
+          isLoading={
+            form.dryRunTransactionMutation.isLoading || form.broadcastTransactionMutation.isLoading
+          }
+          error={broadcastTransactionError || dryRunTransactionError}
           onReset={form.handleMutationsReset}
         />
       </BottomModal>

--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -17,6 +17,7 @@ import { decryptAccount } from 'modules/Auth/utils/decryptAccount';
 import DropDownHolder from 'utilities/alert';
 import { fromPathToObject } from 'utilities/helpers';
 import { useApplicationSupportedTokensQuery } from '../../BlockchainApplication/api/useApplicationSupportedTokensQuery';
+import { DRY_RUN_TRANSACTION_RESULTS } from '../../Transactions/utils/constants';
 
 export default function useSendTokenForm({ transaction, isTransactionSuccess, initialValues }) {
   const [currentAccount] = useCurrentAccount();
@@ -125,7 +126,7 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
           { transaction: encodedTransaction },
           {
             onSettled: ({ data }) => {
-              if (data.result === 1) {
+              if (data.result === DRY_RUN_TRANSACTION_RESULTS.succeed) {
                 broadcastTransactionMutation.mutate({ transaction: encodedTransaction });
               }
             },

--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -121,11 +121,16 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
 
         const encodedTransaction = transaction.encode(signedTransaction).toString('hex');
 
-        await dryRunTransactionMutation.mutate({ transaction: encodedTransaction });
-
-        if (dryRunTransactionMutation.isSuccess) {
-          broadcastTransactionMutation.mutate({ transaction: encodedTransaction });
-        }
+        dryRunTransactionMutation.mutate(
+          { transaction: encodedTransaction },
+          {
+            onSettled: ({ data }) => {
+              if (data.result === 1) {
+                broadcastTransactionMutation.mutate({ transaction: encodedTransaction });
+              }
+            },
+          }
+        );
       } catch (error) {
         DropDownHolder.error(
           i18next.t('Error'),

--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -149,13 +149,19 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
       )?.tokenID;
 
       if (defaultTokenID) {
+        transaction.update({
+          params: {
+            tokenID: defaultTokenID,
+          },
+        });
+
         form.reset({
           ...defaultValues,
           tokenID: defaultTokenID,
         });
       }
     }
-  }, [form, defaultValues, applicationSupportedTokensData]);
+  }, [form, defaultValues, applicationSupportedTokensData, transaction]);
 
   useEffect(() => {
     if (isTransactionSuccess) {

--- a/src/modules/Transactions/api/useDryRunTransactionMutation.js
+++ b/src/modules/Transactions/api/useDryRunTransactionMutation.js
@@ -1,8 +1,8 @@
+// import { useMemo } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
 import { METHOD, API_URL } from 'utilities/api/constants';
 import apiClient from 'utilities/api/APIClient';
-import { useMemo } from 'react';
 
 /**
  * Verifies if a transaction is valid or not based on its params and schema.
@@ -11,7 +11,7 @@ import { useMemo } from 'react';
  * @returns The mutation to trigger the API call.
  */
 export default function useDryRunTransactionMutation({ onSuccess, onError, ...options } = {}) {
-  const mutation = useMutation(
+  return useMutation(
     ({ transaction }) => {
       const config = {
         url: `${API_URL}/transactions/dryrun`,
@@ -36,28 +36,4 @@ export default function useDryRunTransactionMutation({ onSuccess, onError, ...op
       ...options,
     }
   );
-
-  // @TODO: Calculate properly the error message and integrate it with UI.
-  // See https://github.com/LiskHQ/lisk-mobile/issues/1578 for details.
-  const error = useMemo(() => {
-    if (mutation.data?.data.result === -1) {
-      const errorMessage = mutation.data.data.events.map((e) => e.name).join(', ');
-
-      return { message: `Invalid transaction: ${errorMessage}` };
-    }
-
-    if (mutation.data?.data.result === 0) {
-      const errorMessage = mutation.data.data.events.map((e) => e.name).join(', ');
-
-      return { message: `Failed transaction: ${errorMessage}` };
-    }
-
-    return mutation.error;
-  }, [mutation.data?.data.events, mutation.data?.data.result, mutation.error]);
-
-  const isError = useMemo(() => error || mutation.isError, [error, mutation.isError]);
-
-  const isSuccess = useMemo(() => !isError && mutation.isSuccess, [isError, mutation.isSuccess]);
-
-  return { ...mutation, isError, error, isSuccess };
 }

--- a/src/modules/Transactions/components/SignTransaction/SignTransactionError.js
+++ b/src/modules/Transactions/components/SignTransaction/SignTransactionError.js
@@ -16,6 +16,8 @@ export default function SignTransactionError({ onClick, error, actionButton }) {
     styles: getSignTransactionErrorStyles(),
   });
 
+  const errorMessage = error instanceof Error && error.message;
+
   return (
     <View style={[styles.container, styles.theme.container]}>
       <View style={styles.illustrationContainer}>
@@ -26,13 +28,19 @@ export default function SignTransactionError({ onClick, error, actionButton }) {
         {i18next.t('sendToken.result.error.title')}
       </Text>
 
-      <Text style={[styles.description, styles.theme.description]}>
-        {i18next.t('sendToken.result.error.description1')}
-      </Text>
+      {errorMessage ? (
+        <Text style={[styles.description, styles.theme.description]}>{errorMessage}</Text>
+      ) : (
+        <>
+          <Text style={[styles.description, styles.theme.description]}>
+            {i18next.t('sendToken.result.error.description1')}
+          </Text>
 
-      <Text style={[styles.description, styles.theme.description]}>
-        {i18next.t('sendToken.result.error.description2')}
-      </Text>
+          <Text style={[styles.description, styles.theme.description]}>
+            {i18next.t('sendToken.result.error.description2')}
+          </Text>
+        </>
+      )}
 
       {actionButton || (
         <PrimaryButton

--- a/src/modules/Transactions/utils/constants.js
+++ b/src/modules/Transactions/utils/constants.js
@@ -134,3 +134,9 @@ export const PRIORITY_NAMES_MAP = {
   medium: t('sendToken.tokenSelect.mediumPriorityLabel'),
   high: t('sendToken.tokenSelect.highPriorityLabel'),
 };
+
+export const DRY_RUN_TRANSACTION_RESULTS = {
+  invalid: -1,
+  failed: 0,
+  succeed: 1,
+};

--- a/src/modules/Transactions/utils/helpers.js
+++ b/src/modules/Transactions/utils/helpers.js
@@ -99,9 +99,39 @@ export const getTxConstant = ({ moduleAssetId }) => {
     ...result,
     title: result?.title ?? i18next.t('Transaction'),
     image: result?.image
-      ? result?.image
+      ? result?.imageConfirmTransaction
       : (theme) => (theme === themes.light ? txUnknownLight : txUnknownDark),
   };
 };
 
 export const isTransfer = ({ moduleAssetId }) => moduleAssetId === MODULE_COMMAND_MAP.transfer;
+
+/**
+ * Interprets a transaction dry-run error result. Generates an Error instance with descriptive
+ * message if transaction verification failed or is invalid.
+ * @param {Object} responseData - Dry-run transaction response.
+ * @returns {Error} Error with message based on data.result value.
+ * @TODO - Calculate properly the error message and integrate it with UI.
+ * See https://github.com/LiskHQ/lisk-mobile/issues/1578 for details.
+ */
+export function getDryRunTransactionError(responseData) {
+  let error = null;
+
+  const errorMessage = responseData.events.map((e) => e.name).join(', ');
+
+  switch (responseData.result) {
+    case -1:
+      error = new Error(`Transaction is invalid. Reason: ${errorMessage}`);
+
+      break;
+
+    case 0:
+      error = new Error(`Transaction failed. Reason: ${errorMessage}`);
+      break;
+
+    default:
+      break;
+  }
+
+  return error;
+}

--- a/src/modules/Transactions/utils/helpers.js
+++ b/src/modules/Transactions/utils/helpers.js
@@ -5,7 +5,12 @@ import { themes } from 'constants/styleGuide';
 import txUnknownLight from 'assets/images/txDetail/tx-unknown-light.png';
 import txUnknownDark from 'assets/images/txDetail/tx-unknown-dark.png';
 
-import { BASE_TRANSACTION_SCHEMA, MODULE_COMMAND_MAP, TRANSACTIONS } from './constants';
+import {
+  BASE_TRANSACTION_SCHEMA,
+  DRY_RUN_TRANSACTION_RESULTS,
+  MODULE_COMMAND_MAP,
+  TRANSACTIONS,
+} from './constants';
 
 export const getCommandParamsSchema = (module, command, schema) => {
   const moduleCommand = module.concat(':', command);
@@ -120,12 +125,12 @@ export function getDryRunTransactionError(responseData) {
   const errorMessage = responseData.events.map((e) => e.name).join(', ');
 
   switch (responseData.result) {
-    case -1:
+    case DRY_RUN_TRANSACTION_RESULTS.invalid:
       error = new Error(`Transaction is invalid. Reason: ${errorMessage}`);
 
       break;
 
-    case 0:
+    case DRY_RUN_TRANSACTION_RESULTS.failed:
       error = new Error(`Transaction failed. Reason: ${errorMessage}`);
       break;
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #1575

### How was it solved?

- [x] Update also (apart from only the form) the `transaction` instance when `applicationSupportedTokensData` loads
- [x] Handle properly transaction error state on send token.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Simulator
