### PR TITLE
Fix Wallet Connect `BottomModal` close don't reject external connection

### DIFF
--- a/src/navigation/components/Tabs/index.js
+++ b/src/navigation/components/Tabs/index.js
@@ -15,7 +15,7 @@ import useWalletConnectSession from '../../../../libs/wcm/hooks/useSession';
 const Tab = createBottomTabNavigator();
 
 export default function Tabs() {
-  const { session } = useWalletConnectSession();
+  const { session, reject } = useWalletConnectSession();
   const { isOpen: modalOpen } = useContext(ModalContext);
 
   const [
@@ -68,9 +68,11 @@ export default function Tabs() {
 
       <BottomModal
         show={showExternalApplicationSignatureRequestModal}
-        toggleShow={() =>
-          setShowExternalApplicationSignatureRequestModal((prevState) => !prevState)
-        }
+        toggleShow={() => {
+          setShowExternalApplicationSignatureRequestModal((prevState) => !prevState);
+
+          reject();
+        }}
       >
         <ExternalApplicationSignatureRequest
           session={session.request}


### PR DESCRIPTION
### What was the problem?

This PR resolves #1679

### How was it solved?

- [x] Add `reject` cb on external connection `BottomModal` `toggleShow` prop.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
