### PR TITLE
Improvements for cross-chain token transfer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -126,7 +126,8 @@
           ["modules", "./src/modules"],
           ["hooks", "./src/hooks"],
           ["store", "./src/store"],
-          ["tests", "./src/tests"]
+          ["tests", "./src/tests"],
+          ["locales", "./locales"]
         ],
         "extensions": [".js", ".jsx", ".json"]
       }

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,9 @@ module.exports = {
       'module-resolver',
       {
         root: ['./src'],
+        alias: {
+          locales: './locales',
+        },
       },
     ],
   ],

--- a/locales/helpers.js
+++ b/locales/helpers.js
@@ -1,0 +1,11 @@
+/**
+ * Dummy function to help i18n scanner understand i18next translations.
+ * We can remove this as soon as react-navigation supports i18n or
+ * we change the router to another lib with i18n support.
+ *
+ * @param {String} str - String to translate.
+ * @returns {String} Provided input string.
+ */
+export function t(str) {
+  return str;
+}

--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -492,9 +492,8 @@
       "pending": "Ausstehend"
     },
     "errors": {
-      "dryRunRequestErrorDescription": "Fehler beim Validieren Ihrer Transaktion. Bitte versuchen Sie es später erneut.",
-      "dryRunInvalidTransactionTitle": "Ungültige Transaktion",
-      "dryRunInvalidTransactionDescription": "Bitte überprüfen Sie Ihre Eingaben oder laden Sie die App neu und versuchen Sie es erneut.",
+      "dryRunErrorMainMessage": "Beim Validieren der Transaktion ist ein Fehler aufgetreten.",
+      "dryRunErrorReasonMessage": "Grund: {{message}}",
       "broadcastErrorDescription": "Fehler beim Senden Ihrer Transaktion. Bitte versuchen Sie es später erneut.",
       "signErrorDescription": "Fehler beim Signieren Ihrer Transaktion. Bitte versuchen Sie es später erneut."
     }

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -491,9 +491,8 @@
       "pending": "Pending"
     },
     "errors": {
-      "dryRunRequestErrorDescription": "Error validating your transaction. Please try again later.",
-      "dryRunInvalidTransactionTitle": "Invalid transaction",
-      "dryRunInvalidTransactionDescription": "Please check your inputs, or reload the app and try again.",
+      "dryRunErrorMainMessage": "There was an error validating the transaction.",
+      "dryRunErrorReasonMessage": "Reason: {{message}}",
       "broadcastErrorDescription": "Error submitting your transaction. Please try again later.",
       "signErrorDescription": "Error signing your transaction. Please try again later."
     }   

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@craftzdog/react-native-buffer": "^6.0.5",
     "@hookform/resolvers": "^2.9.7",
     "@json-rpc-tools/utils": "^1.7.6",
-    "@liskhq/lisk-client": "6.0.0-alpha.15",
+    "@liskhq/lisk-client": "6.0.0-alpha.16",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-camera-roll/camera-roll": "^5.1.0",
     "@react-native-community/art": "^1.2.0",

--- a/src/assets/svgs/TransactionSvg.js
+++ b/src/assets/svgs/TransactionSvg.js
@@ -21,7 +21,7 @@ export default function TransactionSvg({
 
   switch (moduleCommand) {
     case MODULE_COMMAND_NAMES.tokenTransfer:
-    case MODULE_COMMAND_NAMES.tokenCrossChaintransfer:
+    case MODULE_COMMAND_NAMES.tokenCrossChainTransfer:
       children = (
         <>
           <Path

--- a/src/modules/Network/__fixtures__/mockNetworkStatus.js
+++ b/src/modules/Network/__fixtures__/mockNetworkStatus.js
@@ -18,7 +18,7 @@ export const mockNetworkStatus = {
     registeredModules: ['token', 'reward', 'validators', 'auth', 'fee', 'random', 'legacy'],
     moduleCommands: [
       { id: '00000002:00000000', name: 'token:transfer' },
-      { id: '00000002:00000000', name: 'token:crossChaintransfer' },
+      { id: '00000002:00000000', name: 'token:transferCrossChain' },
       { id: '0000000c:00000000', name: 'auth:registerMultisignatureGroup' },
       { id: '00008000:00000000', name: 'legacy:reclaimLSK' },
       { id: '00008000:00000001', name: 'legacy:registerkeys' },

--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -13,7 +13,7 @@ import { useAccountNonce } from 'modules/Accounts/hooks/useAccountNonce';
 import useDryRunTransactionMutation from 'modules/Transactions/api/useDryRunTransactionMutation';
 import useBroadcastTransactionMutation from 'modules/Transactions/api/useBroadcastTransactionMutation';
 import { useMessageFee } from 'modules/Transactions/hooks/useMessageFee';
-import { TRANSACTION_EXECUTION_RESULT } from 'modules/Transactions/utils/constants';
+import { TRANSACTION_VERIFY_RESULT } from 'modules/Transactions/utils/constants';
 import { decryptAccount } from 'modules/Auth/utils/decryptAccount';
 import { useChainChannelQuery } from 'modules/BlockchainApplication/api/useChainChannelQuery';
 import DropDownHolder from 'utilities/alert';
@@ -128,7 +128,7 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
           { transaction: encodedTransaction },
           {
             onSettled: ({ data }) => {
-              if (data.result === TRANSACTION_EXECUTION_RESULT.ok) {
+              if (data.result !== TRANSACTION_VERIFY_RESULT.invalid) {
                 broadcastTransactionMutation.mutate({ transaction: encodedTransaction });
               }
             },

--- a/src/modules/Transactions/components/TransactionRow/TransactionRow.js
+++ b/src/modules/Transactions/components/TransactionRow/TransactionRow.js
@@ -31,17 +31,15 @@ export default function TransactionRow({ transaction, address }) {
 
   const blurVariant = transactionAssets.amount.sign === '-' ? 'outgoing' : 'incoming';
 
+  const handlePress = () =>
+    navigation.navigate({
+      name: 'TransactionDetails',
+      params: { transactionId: transaction.id, address },
+      key: transaction.id,
+    });
+
   return (
-    <TouchableOpacity
-      onPress={() =>
-        navigation.navigate({
-          name: 'TransactionDetails',
-          params: { transactionId: transaction.id, address },
-          key: transaction.id,
-        })
-      }
-      style={[styles.container, styles.theme.container]}
-    >
+    <TouchableOpacity onPress={handlePress} style={[styles.container, styles.theme.container]}>
       <View style={[styles.row]}>
         {transactionAssets.icon}
 

--- a/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
+++ b/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
@@ -18,10 +18,12 @@ export function TransactionAmount({ transaction, style, address }) {
     sign === '-'
       ? fromRawLsk((BigInt(transaction.params.amount) + BigInt(transaction.fee)).toString())
       : fromRawLsk(BigInt(transaction.params.amount ?? 0).toString());
+
   const transactionAmount = transaction.notRawLisk ? transaction.amount : rawLiskAmount;
 
   if (
-    transactionAssets.type === 'tokenTransfer' &&
+    (transactionAssets.type === 'tokenTransfer' ||
+      transactionAssets.type === 'tokenCrossChainTransfer') &&
     transaction.params.recipientAddress !== transaction.sender.address
   ) {
     return (

--- a/src/modules/Transactions/constants.js
+++ b/src/modules/Transactions/constants.js
@@ -1,14 +1,4 @@
-/**
- * Since react-navigation doesn't support i18n
- * I've created this dummy function to help i18n scanner
- * understand about these titles.
- * We can remove this as soon as react-navigation supports i18n or
- * we change the router to another lib with i18n support.
- *
- * @param {String} str
- * @returns {String} same as the input string
- */
-const t = (str) => str;
+import { t } from 'locales/helpers';
 
 const MODULES = {
   token: 'token',

--- a/src/modules/Transactions/constants.js
+++ b/src/modules/Transactions/constants.js
@@ -20,7 +20,7 @@ const MODULES = {
 
 const COMMANDS = {
   transfer: 'transfer',
-  crossChaintransfer: 'crossChaintransfer',
+  transferCrossChain: 'transferCrossChain',
   registerMultisignatureGroup: 'registerMultisignatureGroup',
   registerDelegate: 'registerDelegate',
   reportDelegateMisbehavior: 'reportDelegateMisbehavior',
@@ -35,7 +35,7 @@ const COMMANDS = {
 
 export const MODULE_COMMAND_NAMES = {
   tokenTransfer: `${MODULES.token}:${COMMANDS.transfer}`,
-  tokenCrossChaintransfer: `${MODULES.token}:${COMMANDS.crossChaintransfer}`,
+  tokenCrossChainTransfer: `${MODULES.token}:${COMMANDS.transferCrossChain}`,
   registerMultisignatureGroup: `${MODULES.auth}:${COMMANDS.registerMultisignatureGroup}`,
   reclaimLSK: `${MODULES.legacy}:${COMMANDS.reclaimLSK}`,
   registerkeys: `${MODULES.legacy}:${COMMANDS.registerkeys}`,

--- a/src/modules/Transactions/hooks/useTransactionAssets.js
+++ b/src/modules/Transactions/hooks/useTransactionAssets.js
@@ -21,7 +21,10 @@ export function useTransactionAssets({ transaction, style, address }) {
     icon: <TransactionSvg moduleCommand={transaction.moduleCommand} style={style?.icon} />,
   };
 
-  if (transaction.moduleCommand === MODULE_COMMAND_NAMES.tokenTransfer) {
+  if (
+    transaction.moduleCommand === MODULE_COMMAND_NAMES.tokenTransfer ||
+    transaction.moduleCommand === MODULE_COMMAND_NAMES.tokenCrossChainTransfer
+  ) {
     if (address !== transaction.sender.address) {
       assets = {
         ...assets,
@@ -50,10 +53,10 @@ export function useTransactionAssets({ transaction, style, address }) {
       };
       break;
 
-    case MODULE_COMMAND_NAMES.tokenCrossChaintransfer:
+    case MODULE_COMMAND_NAMES.tokenCrossChainTransfer:
       assets = {
         ...assets,
-        type: 'tokenCrossChaintransfer',
+        type: 'tokenCrossChainTransfer',
         title: 'Cross-chain Transfer',
       };
       break;

--- a/src/modules/Transactions/utils/constants.js
+++ b/src/modules/Transactions/utils/constants.js
@@ -57,8 +57,8 @@ export const PRIORITY_NAMES_MAP = {
   high: t('sendToken.tokenSelect.highPriorityLabel'),
 };
 
-export const TRANSACTION_EXECUTION_RESULT = {
+export const TRANSACTION_VERIFY_RESULT = {
   invalid: -1,
-  fail: 0,
+  pending: 0,
   ok: 1,
 };

--- a/src/modules/Transactions/utils/constants.js
+++ b/src/modules/Transactions/utils/constants.js
@@ -1,16 +1,7 @@
-/**
- * Since react-navigation doesn't support i18n
- * I've created this dummy function to help i18n scanner
- * understand about these titles.
- * We can remove this as soon as react-navigation supports i18n or
- * we change the router to another lib with i18n support.
- *
- * @param {String} str
- * @returns {String} same as the input string
- */
-const t = (str) => str;
+import { t } from 'locales/helpers';
 
 // TODO: Use from service endpoint/elements.
+
 // (details on https://github.com/LiskHQ/lisk-mobile/issues/1612).
 export const BASE_TRANSACTION_SCHEMA = {
   $id: '/lisk/baseTransaction',

--- a/src/modules/Transactions/utils/helpers.js
+++ b/src/modules/Transactions/utils/helpers.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 import * as Lisk from '@liskhq/lisk-client';
+import i18next from 'i18next';
 
 import { findMaxBigInt } from 'utilities/helpers';
 import { BASE_TRANSACTION_SCHEMA, TRANSACTION_VERIFY_RESULT } from './constants';
@@ -124,12 +125,14 @@ export function getDryRunTransactionError(responseData) {
     return null;
   }
 
-  let message = 'Transaction is invalid.';
+  let message = i18next.t('transactions.errors.dryRunErrorMainMessage');
 
   const responseErrorMessage = responseData.errorMessage;
 
   if (responseErrorMessage && responseData.result) {
-    message += ` Reason: ${responseErrorMessage}`;
+    message += ` ${i18next.t('transactions.errors.dryRunErrorReasonMessage', {
+      message: responseErrorMessage,
+    })}`;
   }
 
   return new Error(message);

--- a/src/modules/Transactions/utils/helpers.js
+++ b/src/modules/Transactions/utils/helpers.js
@@ -2,7 +2,7 @@
 import * as Lisk from '@liskhq/lisk-client';
 
 import { findMaxBigInt } from 'utilities/helpers';
-import { BASE_TRANSACTION_SCHEMA, TRANSACTION_EXECUTION_RESULT } from './constants';
+import { BASE_TRANSACTION_SCHEMA, TRANSACTION_VERIFY_RESULT } from './constants';
 
 export const getCommandParamsSchema = (module, command, schema) => {
   const moduleCommand = module.concat(':', command);
@@ -118,27 +118,19 @@ export function computeNonce(authNonce, transactionPool) {
  * See https://github.com/LiskHQ/lisk-mobile/issues/1578 for details.
  */
 export function getDryRunTransactionError(responseData) {
-  let error;
-  let reasonMessage = '';
+  const isError = responseData.result === TRANSACTION_VERIFY_RESULT.invalid;
+
+  if (!isError) {
+    return null;
+  }
+
+  let message = 'Transaction is invalid.';
 
   const responseErrorMessage = responseData.errorMessage;
 
   if (responseErrorMessage && responseData.result) {
-    reasonMessage = `Reason: ${responseErrorMessage}`;
+    message += ` Reason: ${responseErrorMessage}`;
   }
 
-  switch (responseData.result) {
-    case TRANSACTION_EXECUTION_RESULT.invalid:
-      error = new Error(`Transaction is invalid. ${reasonMessage}`);
-      break;
-
-    case TRANSACTION_EXECUTION_RESULT.fail:
-      error = new Error(`Transaction failed. ${reasonMessage}`);
-      break;
-
-    default:
-      break;
-  }
-
-  return error;
+  return new Error(message);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,47 +1456,47 @@
     "@json-rpc-tools/types" "^1.7.6"
     "@pedrouid/environment" "^1.0.1"
 
-"@liskhq/lisk-api-client@^6.0.0-alpha.15":
-  version "6.0.0-alpha.15"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.15.tgz#1d010293dbce9c261d2a79f797353ed72625f11d"
-  integrity sha512-Ktgjq8AnK25o7T2Chk9nwkOaUbifdOGtHIGCK5cmDo47pswUillW1tlfUHUrh6/oM3c5bvUOpmW6dur7snWyAw==
+"@liskhq/lisk-api-client@^6.0.0-alpha.16":
+  version "6.0.0-alpha.16"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.16.tgz#a3b2a800a7f13a0ad74ec6d0236b11164842eacc"
+  integrity sha512-BznpTSGs6BgC8a8wyolP0sPJP3tzdRejcck7MJkyRbGBpYAMoSfw3Brlzq86yk5mIH1HQzvKNbHDKQH3FjYnzQ==
   dependencies:
-    "@liskhq/lisk-codec" "^0.3.0-alpha.8"
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
-    "@liskhq/lisk-transactions" "^6.0.0-alpha.11"
-    "@liskhq/lisk-validator" "^0.7.0-alpha.6"
+    "@liskhq/lisk-codec" "^0.3.0-alpha.9"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
+    "@liskhq/lisk-transactions" "^6.0.0-alpha.12"
+    "@liskhq/lisk-validator" "^0.7.0-alpha.7"
     isomorphic-ws "4.0.1"
     ws "8.11.0"
     zeromq "6.0.0-beta.6"
 
-"@liskhq/lisk-client@6.0.0-alpha.15":
-  version "6.0.0-alpha.15"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.15.tgz#dde439fd68ea413f25d56f2174aa325d482393ce"
-  integrity sha512-ffC5NelS9C2UJCrEQvEfdCqf531EYMzW+nY8wFRtQzN/ZK02mNpuO6L5pLFTWunQBbrSbawk3KW8aRZuTpb1kw==
+"@liskhq/lisk-client@6.0.0-alpha.16":
+  version "6.0.0-alpha.16"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.16.tgz#ab7daef844cb136dffb4e63285e6cddd85cc10ce"
+  integrity sha512-rkrW9pk8Bd83OoMQ5ojL8R5/i48tmIBb/9RYr/hNj5wC22CHRp+ktSh5EYPoFnigT5awBeJ2wfNm/5zC9PD0+g==
   dependencies:
-    "@liskhq/lisk-api-client" "^6.0.0-alpha.15"
-    "@liskhq/lisk-codec" "^0.3.0-alpha.8"
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
+    "@liskhq/lisk-api-client" "^6.0.0-alpha.16"
+    "@liskhq/lisk-codec" "^0.3.0-alpha.9"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
     "@liskhq/lisk-passphrase" "^4.0.0-alpha.2"
-    "@liskhq/lisk-transactions" "^6.0.0-alpha.11"
-    "@liskhq/lisk-tree" "^0.3.0-alpha.9"
+    "@liskhq/lisk-transactions" "^6.0.0-alpha.12"
+    "@liskhq/lisk-tree" "^0.3.0-alpha.10"
     "@liskhq/lisk-utils" "^0.3.0-alpha.4"
-    "@liskhq/lisk-validator" "^0.7.0-alpha.6"
+    "@liskhq/lisk-validator" "^0.7.0-alpha.7"
     buffer "6.0.3"
 
-"@liskhq/lisk-codec@^0.3.0-alpha.8":
-  version "0.3.0-alpha.8"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.8.tgz#3117e444f40be0835075fe8f3f48743520e460dd"
-  integrity sha512-AM7Juadk4+zKz67DQFmvTFrjTQqqyCNK7BLxQ+WgAv5sdJPgcujSfLaKTSoL7hoLiE6Z4l0NMrDaU0ZMlJI2vQ==
+"@liskhq/lisk-codec@^0.3.0-alpha.9":
+  version "0.3.0-alpha.9"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.9.tgz#4c9008cf7d3ea196a8a63f241af52519fd6f3bf9"
+  integrity sha512-KDgODq54d5zuA9hT7bnDAjVxrsZZhqnP6LRgM/oqvmFHAgcZb4AKk4jmEhLLINWwj0LvK70Jd96tYbn6/ZbUwQ==
   dependencies:
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
     "@liskhq/lisk-utils" "^0.3.0-alpha.4"
-    "@liskhq/lisk-validator" "^0.7.0-alpha.6"
+    "@liskhq/lisk-validator" "^0.7.0-alpha.7"
 
-"@liskhq/lisk-cryptography@^4.0.0-alpha.6":
-  version "4.0.0-alpha.6"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz#79145454cc8a7c3eb920fd5844341580a6948d07"
-  integrity sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==
+"@liskhq/lisk-cryptography@^4.0.0-alpha.7":
+  version "4.0.0-alpha.7"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.7.tgz#ab8f7b70ebdb49ec4b5a5ba5d19774f92bbcc00d"
+  integrity sha512-/dlVsJzjJ2z4IlbfVf87gWqB5p3xESqQKt8cRP94XZ38VmsQF2PpuZEEuyGEM9IbOYzT7kpdfQ+Fz7X7ZWiWuQ==
   dependencies:
     "@liskhq/lisk-passphrase" "^4.0.0-alpha.2"
     buffer-reverse "1.0.1"
@@ -1512,21 +1512,21 @@
   dependencies:
     bip39 "3.0.3"
 
-"@liskhq/lisk-transactions@^6.0.0-alpha.11":
-  version "6.0.0-alpha.11"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.11.tgz#9d7219e1fcaaa97b4ede0dab00bdda01d72f1d31"
-  integrity sha512-XJws8QMr6kZoXZ3dVLKEn6lKWuEh90CFdz7RWAxbdCLw2BKWoNzK+haXC6djIPTrgHhIVsQukHDf/9HcIVbtmA==
+"@liskhq/lisk-transactions@^6.0.0-alpha.12":
+  version "6.0.0-alpha.12"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.12.tgz#04c733a630ec8ccf63e7b3dbf8507f516224b7c7"
+  integrity sha512-nPJR22tOG9LtojMiq5KVWfoYK1Cc8WJ7iHJgoboIvufD5PV1Zq1CZ5NQhx3ZZlOPffcs7OtVSOF32twheh2BWQ==
   dependencies:
-    "@liskhq/lisk-codec" "^0.3.0-alpha.8"
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
-    "@liskhq/lisk-validator" "^0.7.0-alpha.6"
+    "@liskhq/lisk-codec" "^0.3.0-alpha.9"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
+    "@liskhq/lisk-validator" "^0.7.0-alpha.7"
 
-"@liskhq/lisk-tree@^0.3.0-alpha.9":
-  version "0.3.0-alpha.9"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.9.tgz#3b569d6d2232659de719f509b4d41754314d55d9"
-  integrity sha512-nilsdzCCdXGT1ONEMdh5/DGSII7oS0l5ZZ38zCdOmkL+UG5RKjelVw3N8JSPFpHPliNX3J/2sTY3s/BhTi43xw==
+"@liskhq/lisk-tree@^0.3.0-alpha.10":
+  version "0.3.0-alpha.10"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.10.tgz#323aa9942ff14643cb7721b268214690cb3738ee"
+  integrity sha512-coT0XqI09r4r1Mx73CpzCCMEt0AJicODTHel0X2bhxlieIf7U6afcK0Zorv19teOps4IBc66X7rb9hAcC1hVDw==
   dependencies:
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
     "@liskhq/lisk-utils" "^0.3.0-alpha.4"
 
 "@liskhq/lisk-utils@^0.3.0-alpha.4":
@@ -1536,12 +1536,12 @@
   dependencies:
     lodash.clonedeep "4.5.0"
 
-"@liskhq/lisk-validator@^0.7.0-alpha.6":
-  version "0.7.0-alpha.6"
-  resolved "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.6.tgz#b8bcf4e59aad5ef5b6a52a842e70055e5b68ec1e"
-  integrity sha512-l+OmCMNx7/ACIn1/U5PgXTa4LyEDL+q80Xq+5e9p/uxuy5noJhEFUtDqttPsLOtqjUYZWGq/pzSdGuQSNrbokg==
+"@liskhq/lisk-validator@^0.7.0-alpha.7":
+  version "0.7.0-alpha.7"
+  resolved "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.7.tgz#64b9c189bd3db7ba424f101cc16ebaa6a66bc420"
+  integrity sha512-2rJopUelN2kefPjNsb88Jvkwl9PMp3Wl4jCL4Ce3Ogdk18fXwZfL1LeZQ3yOCc0bF9BAP8qG+K7c33SxKFo+nQ==
   dependencies:
-    "@liskhq/lisk-cryptography" "^4.0.0-alpha.6"
+    "@liskhq/lisk-cryptography" "^4.0.0-alpha.7"
     ajv "8.1.0"
     ajv-formats "2.1.1"
     debug "4.3.4"


### PR DESCRIPTION
### What was the problem?

This PR resolves #1717

### How was it solved?

- [x] Bump `lisk-client` to `v6.0.0-alpha.16`
- [x] Update transaction dryrun check to consider new 'pending' result. Change `getDryRunTransactionError` business logic and broadcast transaction execution check to also pass when dryrun return `pending` as result status.
- [x] Fix crosschain token:transfer transaction row rendering. Updated `transferCrossChain` command constant and added crosschain tx type for the amount rendering.


### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
