### PR TITLE
Non active blockchain applications are listed in cross chain transfer

### DIFF
--- a/src/modules/BlockchainApplication/constants.js
+++ b/src/modules/BlockchainApplication/constants.js
@@ -1,2 +1,9 @@
 export const APPLICATIONS_STORAGE_KEY = '@blockchainApplications';
+
 export const PINNED_APPLICATIONS_STORAGE_KEY = '@blockchainPinnedApplications';
+
+export const APPLICATION_STATUSES = {
+  active: 'active',
+  registered: 'registered',
+  terminated: 'terminated',
+};

--- a/src/modules/SendToken/components/SelectApplicationsStep/components.js
+++ b/src/modules/SendToken/components/SelectApplicationsStep/components.js
@@ -6,6 +6,7 @@ import i18next from 'i18next';
 
 import { useTheme } from 'contexts/ThemeContext';
 import { BookmarkList } from 'modules/Bookmark/components';
+import { APPLICATION_STATUSES } from 'modules/BlockchainApplication/constants';
 import { selectBookmarkList } from 'modules/Bookmark/store/selectors';
 import Picker from 'components/shared/Picker';
 import Avatar from 'components/shared/avatar';
@@ -67,7 +68,9 @@ export function SendTokenRecipientApplicationField({
   applications,
   style,
 }) {
-  const applicationsOptions = applications.filter((application) => application.status === 'active');
+  const applicationsOptions = applications.filter(
+    (application) => application.status === APPLICATION_STATUSES.active
+  );
 
   const recipientApplication = applicationsOptions.find(
     (application) => application.chainID === value

--- a/src/modules/SendToken/components/SelectApplicationsStep/components.js
+++ b/src/modules/SendToken/components/SelectApplicationsStep/components.js
@@ -67,7 +67,11 @@ export function SendTokenRecipientApplicationField({
   applications,
   style,
 }) {
-  const recipientApplication = applications.find((application) => application.chainID === value);
+  const applicationsOptions = applications.filter((application) => application.status === 'active');
+
+  const recipientApplication = applicationsOptions.find(
+    (application) => application.chainID === value
+  );
 
   const { styles } = useTheme({
     styles: getSendTokenSelectApplicationsStepStyles(),
@@ -75,7 +79,7 @@ export function SendTokenRecipientApplicationField({
 
   const renderMenuItems = () => (
     <InfiniteScrollList
-      data={applications}
+      data={applicationsOptions}
       keyExtractor={(item) => item.chainID}
       renderItem={(item) => (
         <Picker.Item key={item.chainID} value={item.chainID} onChange={onChange}>


### PR DESCRIPTION
### What was the problem?

This PR resolves #1662

### How was it solved?

- [x] Filter recipient application picker options to only active apps on token:transfer form.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.