### PR TITLE
Fix charging initialisation fee for an initialised account

### DIFF
--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -82,18 +82,18 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
   const recipientAddress = form.watch('recipientAccountAddress');
   const tokenID = form.watch('tokenID');
 
-  const isCrossChainTransaction = senderApplicationChainID !== recipientApplicationChainID;
+  const isCrossChainTransfer = senderApplicationChainID !== recipientApplicationChainID;
 
   const { data: recipientApplicationChainChannelData } = useChainChannelQuery(
     recipientApplicationChainID,
-    { options: { enabled: isCrossChainTransaction } }
+    { options: { enabled: isCrossChainTransfer } }
   );
 
   const { data: initializationFeeData, refetch: refetchInitializationFee } = useInitializationFee({
     address: recipientAddress,
     tokenID,
     enabled: false,
-    isCrossChainTransaction,
+    isCrossChainTransfer,
   });
 
   const handleChange = (field, value, onChange) => {
@@ -210,7 +210,7 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
     }
 
     if (
-      isCrossChainTransaction &&
+      isCrossChainTransfer &&
       messageFeeData?.data?.fee &&
       recipientApplicationChainChannelData?.data?.messageFeeTokenID
     ) {
@@ -227,7 +227,7 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
       transaction.deleteParams(['messageFee', 'receivingChainID', 'messageFeeTokenID']);
     }
   }, [
-    isCrossChainTransaction,
+    isCrossChainTransfer,
     recipientApplicationChainChannelData?.data?.messageFeeTokenID,
     messageFeeData?.data?.fee,
     recipientApplicationChainID,

--- a/src/modules/Transactions/hooks/useCreateTransaction.js
+++ b/src/modules/Transactions/hooks/useCreateTransaction.js
@@ -9,7 +9,6 @@ import { useCommandParametersSchemasQuery } from 'modules/Network/api/useCommand
 
 import { Transaction } from '../utils/Transaction';
 import { usePriorityFee } from './usePriorityFee';
-import { useInitializationFee } from './useInitializationFee';
 
 /**
  * Creates a transaction object with all required build-in
@@ -54,33 +53,23 @@ export function useCreateTransaction({ module = null, command = null, encodedTra
     isError: isErrorPriorityFee,
   } = usePriorityFee();
 
-  const {
-    data: initializationFeeData,
-    isLoading: isInitializationFeeLoading,
-    isSuccess: isInitializationFeeSuccess,
-    isError: isErrorInitializationFee,
-  } = useInitializationFee();
-
   const isLoading =
     isNetworkStatusLoading ||
     isAuthLoading ||
     isCommandParametersSchemasLoading ||
-    isPriorityFeeLoading ||
-    isInitializationFeeLoading;
+    isPriorityFeeLoading;
 
   const isSuccess =
     isNetworkStatusSuccess &&
     isAuthSuccess &&
     isCommandParametersSchemasSuccess &&
-    isPriorityFeeSuccess &&
-    isInitializationFeeSuccess;
+    isPriorityFeeSuccess;
 
   const isError =
     isErrorOnNetworkStatus ||
     isErrorOnAuth ||
     isErrorOnCommandParametersSchemas ||
-    isErrorPriorityFee ||
-    isErrorInitializationFee;
+    isErrorPriorityFee;
 
   const transactionSchema = commandParametersSchemasData?.data?.transaction?.schema;
 
@@ -92,7 +81,6 @@ export function useCreateTransaction({ module = null, command = null, encodedTra
           networkStatus: networkStatusData?.data,
           auth: authData,
           priorityFee: priorityFeeData,
-          extraCommandFee: initializationFeeData,
           commandParametersSchemas: commandParametersSchemasData?.data.commands,
           module,
           command,

--- a/src/modules/Transactions/hooks/useInitializationFee.js
+++ b/src/modules/Transactions/hooks/useInitializationFee.js
@@ -26,7 +26,6 @@ export function useInitializationFee({
   const initializationFeesQueryConfig = {
     data: {
       endpoint: 'token_getInitializationFees',
-      params: {},
     },
   };
 

--- a/src/modules/Transactions/hooks/useInitializationFee.js
+++ b/src/modules/Transactions/hooks/useInitializationFee.js
@@ -6,7 +6,7 @@ import { useInvokeQuery } from 'utilities/api/hooks/useInvokeQuery';
  * for a given account and token.
  * @param {string} params.address - Account address to verify existence (fee will be 0 if des not exist).
  * @param {string} params.tokenID - Token ID to verify the account address existence.
- * @param {boolean} params.isCrossChainTransaction - Flag that indicates if transaction is cross-chain or not (default: false).
+ * @param {boolean} params.isCrossChainTransfer - Flag that indicates if transaction is cross-chain or not (default: false).
  * @param {QueryOptions} params.options - Initialization fee query custom options.
  * @param {boolean} params.enabled - Flag that indicates if the hook queries are enabled or not. Default is true.
  * @returns {QueryResult<number>} Query state: data (initialization fee), isLoading, isError, error and more.
@@ -14,7 +14,7 @@ import { useInvokeQuery } from 'utilities/api/hooks/useInvokeQuery';
 export function useInitializationFee({
   address,
   tokenID,
-  isCrossChainTransaction = false,
+  isCrossChainTransfer = false,
   options = {},
   enabled = true,
 } = {}) {
@@ -60,7 +60,7 @@ export function useInitializationFee({
 
   const data = isAccountInitialised
     ? 0
-    : initializationFeesQueryData?.data[isCrossChainTransaction ? 'userAccount' : 'escrowAccount'];
+    : initializationFeesQueryData?.data[isCrossChainTransfer ? 'userAccount' : 'escrowAccount'];
   const isLoading = isLoadingIsAccountInitialisedQuery || isLoadingInitializationFeesQuery;
   const isError = isErrorIsAccountInitialisedQuery || isErrorInitializationFeesQuery;
   const error = errorIsAccountInitialisedQuery || errorErrorInitializationFeesQuery;

--- a/src/modules/Transactions/hooks/useInitializationFee.js
+++ b/src/modules/Transactions/hooks/useInitializationFee.js
@@ -4,17 +4,19 @@ import { useInvokeQuery } from 'utilities/api/hooks/useInvokeQuery';
 /**
  * Calculates the initialization fee (or extra command fee) of a transaction
  * for a given account and token.
- * @param {Object} params.options - Query custom options.
- * @param {String} params.address - Account address to verify existence (fee will be 0 if des not exist).
- * @param {String} params.tokenID - Token ID to verify the account address existence.
- * @param {Boolean} params.isCrossChainTransaction - Flag that indicates if transaction is cross-chain or not (default: false).
- * @returns {Object} Query state: data, isLoading, isError, error and isSuccess.
+ * @param {string} params.address - Account address to verify existence (fee will be 0 if des not exist).
+ * @param {string} params.tokenID - Token ID to verify the account address existence.
+ * @param {boolean} params.isCrossChainTransaction - Flag that indicates if transaction is cross-chain or not (default: false).
+ * @param {QueryOptions} params.options - Initialization fee query custom options.
+ * @param {boolean} params.enabled - Flag that indicates if the hook queries are enabled or not. Default is true.
+ * @returns {QueryResult<number>} Query state: data (initialization fee), isLoading, isError, error and more.
  */
 export function useInitializationFee({
-  options = {},
   address,
   tokenID,
   isCrossChainTransaction = false,
+  options = {},
+  enabled = true,
 } = {}) {
   const isAccountInitialisedQueryConfig = {
     data: {
@@ -35,8 +37,10 @@ export function useInitializationFee({
     isErrorIsAccountInitialisedQuery,
     error: errorIsAccountInitialisedQuery,
     isSuccess: isSuccessIsAccountInitialisedQuery,
+    refetch: refetchAccountInitialisedQuery,
   } = useInvokeQuery({
     config: isAccountInitialisedQueryConfig,
+    options: { enabled },
   });
 
   const isAccountInitialised = isAccountInitialisedQueryData?.data.exists;
@@ -49,8 +53,10 @@ export function useInitializationFee({
     isSuccess: isSuccessErrorInitializationFeesQuery,
   } = useInvokeQuery({
     config: initializationFeesQueryConfig,
-    options: { ...options, enabled: !isAccountInitialised },
+    options: { ...options, enabled: isAccountInitialised === false },
   });
+
+  const refetch = () => refetchAccountInitialisedQuery();
 
   const data = isAccountInitialised
     ? 0
@@ -60,5 +66,5 @@ export function useInitializationFee({
   const error = errorIsAccountInitialisedQuery || errorErrorInitializationFeesQuery;
   const isSuccess = isSuccessIsAccountInitialisedQuery && isSuccessErrorInitializationFeesQuery;
 
-  return { data, isLoading, isError, error, isSuccess };
+  return { data, isLoading, isError, error, isSuccess, refetch };
 }

--- a/src/modules/Transactions/utils/Transaction.js
+++ b/src/modules/Transactions/utils/Transaction.js
@@ -26,7 +26,7 @@ export class Transaction {
 
   _priorityFee = null;
 
-  _extraCommandFee = null;
+  extraCommandFee = null;
 
   transaction = {
     module: null,
@@ -61,7 +61,7 @@ export class Transaction {
     this._auth = auth;
     this._paramsSchemas = commandParametersSchemas;
     this._priorityFee = priorityFee;
-    this._extraCommandFee = BigInt(extraCommandFee || 0);
+    this.extraCommandFee = BigInt(extraCommandFee || 0);
     this.transaction.senderPublicKey = Buffer.isBuffer(pubkey)
       ? pubkey
       : Buffer.from(pubkey, 'hex');
@@ -105,11 +105,16 @@ export class Transaction {
     command = this.transaction.command,
     params = {},
     nonce = null,
+    extraCommandFee = null,
     ...others
   }) {
     if (this.module || !command || !this._paramsSchema) {
       return this.transaction;
     }
+
+    this.extraCommandFee =
+      extraCommandFee !== null ? BigInt(extraCommandFee) : this.extraCommandFee;
+
     this._computeParamsSchema(module, command);
 
     const updatedTransaction = {
@@ -206,7 +211,7 @@ export class Transaction {
 
     const options = {
       numberOfSignatures,
-      additionalFee: this._extraCommandFee + extraFee,
+      additionalFee: this.extraCommandFee + extraFee,
     };
 
     const minFee = Lisk.transactions.computeMinFee(
@@ -228,6 +233,8 @@ export class Transaction {
     const fee = minFee + priorityFee;
 
     this.transaction = { ...this.transaction, fee };
+
+    return fee;
   }
 
   /**
@@ -237,7 +244,7 @@ export class Transaction {
   getFeeBreakdown() {
     const totalFee = this.transaction.fee;
     const priorityFee = this._getPriorityFee();
-    const extraCommandFee = this._extraCommandFee;
+    const extraCommandFee = this.extraCommandFee;
     const byteFee = totalFee - priorityFee - extraCommandFee;
 
     return { totalFee, priorityFee, byteFee, extraCommandFee };


### PR DESCRIPTION
### What was the problem?

This PR resolves #1727

### How was it solved?

- [x] Fetch extra command fee dynamically based on recipientAddress and tokenID change on token:transfer form.
- [x] Disable initialisation fee query when recipientAddress and tokenID are not selected on
token:transfer form. Allow refetch query to trigger dynamically on input changes.


https://user-images.githubusercontent.com/9727036/228265215-6608f9ec-f5c4-4f3d-84cb-824c887a6a4b.mp4



### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
