### PR TITLE
Fix disable token transfer button for accounts with no balance

### DIFF
--- a/src/modules/Accounts/components/AccountDetails/AccountDetails.js
+++ b/src/modules/Accounts/components/AccountDetails/AccountDetails.js
@@ -16,6 +16,7 @@ import useAccountManagerModal from '../../hooks/useAccountManagerModal';
 
 import getAccountDetailsStyles from './AccountDetails.styles';
 import { useCurrentAccount } from '../../hooks/useCurrentAccount';
+import { useAccountCanSendTokens } from '../../../SendToken/hooks/useAccountCanSendTokens';
 
 /**
  * Renders a account detailed information (personal data, tokens and transactions) given an address.
@@ -31,6 +32,15 @@ export default function AccountDetails({ account }) {
   const { styles } = useTheme({ styles: getAccountDetailsStyles() });
 
   const isCurrentAccount = currentAccount.metadata.address === account.address;
+
+  const {
+    data: accountCanSendTokensData,
+    isLoading: isLoadingAccountCanSendTokens,
+    isError: isErrorAccountCanSendTokens,
+  } = useAccountCanSendTokens(account.address);
+
+  const disableSendTokenButton =
+    !accountCanSendTokensData || isLoadingAccountCanSendTokens || isErrorAccountCanSendTokens;
 
   const handleRequestTokensClick = () => navigation.navigate('Request');
 
@@ -91,6 +101,7 @@ export default function AccountDetails({ account }) {
           <TouchableOpacity
             style={[styles.button, styles.sendButton]}
             onPress={handleSendTokensClick}
+            disabled={disableSendTokenButton}
           >
             <P style={[styles.buttonText, styles.sendButtonText]}>Send</P>
           </TouchableOpacity>

--- a/src/modules/SendToken/hooks/useAccountCanSendTokens.js
+++ b/src/modules/SendToken/hooks/useAccountCanSendTokens.js
@@ -1,0 +1,17 @@
+import { useAccountTokensQuery } from 'modules/Accounts/api/useAccountTokensQuery';
+
+/**
+ * Checks if an account is available or not to send tokens based on its balance.
+ * @param {string} address - Address of the account to query the tokens from.
+ * @returns {QueryResult<boolean>} - The state of the account query and if has or not balance to transfer tokens (as data field).
+ */
+export function useAccountCanSendTokens(address) {
+  const accountTokensQuery = useAccountTokensQuery(address);
+
+  const hasBalance = accountTokensQuery.data?.data.reduce(
+    (acc, token) => acc || BigInt(token.availableBalance) > 0,
+    false
+  );
+
+  return { ...accountTokensQuery, data: hasBalance };
+}

--- a/src/modules/SendToken/hooks/useAccountCanSendTokens.test.js
+++ b/src/modules/SendToken/hooks/useAccountCanSendTokens.test.js
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAccountTokensQuery } from 'modules/Accounts/api/useAccountTokensQuery';
+import { mockSavedAccounts } from 'modules/Accounts/__fixtures__';
+
+import { useAccountCanSendTokens } from './useAccountCanSendTokens';
+
+jest.mock('modules/Accounts/api/useAccountTokensQuery');
+
+describe('useAccountCanSendTokens', () => {
+  beforeEach(() => {
+    useAccountTokensQuery.mockClear();
+  });
+
+  const mockedAddress = mockSavedAccounts[0].metadata.address;
+
+  it('should return loading state when account tokens query is loading', () => {
+    useAccountTokensQuery.mockReturnValue({
+      isLoading: true,
+      data: null,
+      isError: false,
+    });
+    const { result } = renderHook(() => useAccountCanSendTokens(mockedAddress));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should return error state when account tokens query returns an error', () => {
+    useAccountTokensQuery.mockReturnValue({
+      isLoading: false,
+      data: null,
+      isError: true,
+    });
+    const { result } = renderHook(() => useAccountCanSendTokens(mockedAddress));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('should return false when account tokens query returns empty data array', () => {
+    useAccountTokensQuery.mockReturnValue({
+      isLoading: false,
+      data: { data: [] },
+      isError: false,
+    });
+    const { result } = renderHook(() => useAccountCanSendTokens(mockedAddress));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should return false when all account tokens have no available balance', () => {
+    useAccountTokensQuery.mockReturnValue({
+      isLoading: false,
+      data: { data: [{ availableBalance: 0 }] },
+      isError: false,
+    });
+    const { result } = renderHook(() => useAccountCanSendTokens(mockedAddress));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should return true when at least one account token has available balance', () => {
+    useAccountTokensQuery.mockReturnValue({
+      isLoading: false,
+      data: { data: [{ availableBalance: 0 }, { availableBalance: 100 }] },
+      isError: false,
+    });
+    const { result } = renderHook(() => useAccountCanSendTokens(mockedAddress));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #1729

### How was it solved?

- [x] Add `useAccountCanSendTokens` hook.
- [x] Disable send token button for accounts with no balance.
- [x] Add UT for `useAccountCanSendTokens`.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
