### PR TITLE
Fix users doesn't receive transaction updates

### DIFF
--- a/src/utilities/helpers.js
+++ b/src/utilities/helpers.js
@@ -204,3 +204,17 @@ export function joinArraysWithoutDuplicates(arr1, arr2, filterProp) {
   // Return the uniqueObjects array
   return uniqueObjects;
 }
+
+/**
+ * Pushes into arr1 the elements of arr2 following a FIFO (queue) approach and maintaining arr1 length.
+ * @param {Array} arr1 - The array to add elements to.
+ * @param {Array} arr2 - The array containing elements to add.
+ * @return {Array} - The modified array.
+ */
+export function queuePush(arr1, arr2) {
+  const concatArrays = [...arr2, ...arr1];
+
+  const queue = concatArrays.slice(0, arr1.length);
+
+  return queue;
+}

--- a/src/utilities/helpers.test.js
+++ b/src/utilities/helpers.test.js
@@ -11,6 +11,7 @@ import {
   isNumeric,
   joinArraysWithoutDuplicates,
   findMaxBigInt,
+  queuePush,
 } from './helpers';
 
 describe('helpers', () => {
@@ -256,6 +257,51 @@ describe('helpers', () => {
     it('should return the only value in an array with a single element', () => {
       const arr = [BigInt(123)];
       expect(findMaxBigInt(arr)).toBe(123n);
+    });
+  });
+
+  describe('queuePush', () => {
+    it('should add elements to the beginning of the array without changing its length', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5];
+      const result = queuePush(arr1, arr2);
+      expect(result).toEqual([4, 5, 1]);
+    });
+
+    it('should handle arrays of equal length', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5, 6];
+      const result = queuePush(arr1, arr2);
+      expect(result).toEqual([4, 5, 6]);
+    });
+
+    it('should handle arrays where arr2 is shorter than arr1', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4];
+      const result = queuePush(arr1, arr2);
+      expect(result).toEqual([4, 1, 2]);
+    });
+
+    it('should handle arrays where arr2 is longer than arr1', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5, 6, 2];
+      const result = queuePush(arr1, arr2);
+      expect(result).toEqual([4, 5, 6]);
+    });
+
+    it('should handle arrays of different lengths', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5];
+      const result = queuePush(arr1, arr2);
+      expect(result).toEqual([4, 5, 1]);
+    });
+
+    it('should not modify the original arrays', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5];
+      queuePush(arr1, arr2);
+      expect(arr1).toEqual([1, 2, 3]);
+      expect(arr2).toEqual([4, 5]);
     });
   });
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #1732

### How was it solved?

- Update way of handling `new.transactions` event for `GET_ACCOUNT_TRANSACTIONS_QUERY`.  Since invalidation of query don't ensure that the new transaction is indexed (service way of working with new broadcasted transactions), `GET_ACCOUNT_TRANSACTIONS_QUERY` needs to be manually cache-updated.

### How was it tested?

- [x] iOS Simulator.
- [ ] Android Emulator.
