### PR TITLE
Fix handle amount validation for send and request token

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -460,7 +460,6 @@
       "recipientLabel": "Empfänger",
       "transactionFeeLabel": "Transaktionsgebühr",
       "nonceLabel": "Nonce",
-      "confirmationsLabel": "Bestätigungen",
       "statusLabel": "Status",
       "transactionIDLabel": "Transaktion ID",
       "blockIDLabel": "Block ID",

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -459,7 +459,6 @@
       "recipientLabel": "Recipient",
       "transactionFeeLabel": "Transaction Fee",
       "nonceLabel": "Nonce",
-      "confirmationsLabel": "Confirmations",
       "statusLabel": "Status",
       "transactionIDLabel": "Transaction ID",
       "blockIDLabel": "Block ID",

--- a/src/modules/Accounts/components/TokenList/TokenList.js
+++ b/src/modules/Accounts/components/TokenList/TokenList.js
@@ -16,7 +16,7 @@ import EmptyIllustrationSvg from 'assets/svgs/EmptyIllustrationSvg';
 import ErrorIllustrationSvg from 'assets/svgs/ErrorIllustrationSvg';
 import DataRenderer from 'components/shared/DataRenderer';
 import { LIMIT } from 'utilities/api/constants';
-import { useAccountTokensQuery } from '../../api/useAccountTokensQuery';
+import { useAccountTokensFullDataQuery } from '../../api/useAccountTokensFullDataQuery';
 import TokenRow from '../TokenRow/TokenRow';
 
 import TokenListTabs from './components/TokenListTabs';
@@ -39,7 +39,7 @@ export default function TokenList({ mode = 'overview', address, style }) {
     fetchNextPage: fetchNextTokensPage,
     hasNextPage: hasTokensNextPage,
     isFetchingNextPage: isFetchingTokensNextPage,
-  } = useAccountTokensQuery(address, {
+  } = useAccountTokensFullDataQuery({
     config: {
       params: { limit: mode === 'overview' ? NO_OF_TOKENS_ON_OVERVIEW : LIMIT },
     },

--- a/src/modules/Accounts/components/TokenRow/TokenRow.js
+++ b/src/modules/Accounts/components/TokenRow/TokenRow.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-statements */
 import React from 'react';
 import { View, Image } from 'react-native';
-import * as Lisk from '@liskhq/lisk-client';
 import { useSelector } from 'react-redux';
 
 import { useTheme } from 'contexts/ThemeContext';
@@ -10,14 +9,17 @@ import { useTokenAmountInCurrency } from 'modules/SendToken/components/SelectTok
 import DataRenderer from 'components/shared/DataRenderer';
 import { P, H3 } from 'components/shared/toolBox/typography';
 import DiscreteModeComponent from 'components/shared/DiscreteModeComponent';
-import { fromRawLsk } from 'utilities/conversions.utils';
+import { fromBaseToDisplayDenom } from 'utilities/conversions.utils';
 
 import getTokenRowStyles from './TokenRow.styles';
 
 export default function TokenRow({ token }) {
-  // eslint-disable-next-line no-undef
   const balance = Number(
-    fromRawLsk(BigInt(token.availableBalance ?? 0).toString())
+    fromBaseToDisplayDenom({
+      amount: token.availableBalance,
+      displayDenom: token.displayDenom,
+      denomUnits: token.denomUnits,
+    })
   ).toLocaleString();
 
   const accountSettings = useSelector((state) => state.settings);
@@ -29,7 +31,11 @@ export default function TokenRow({ token }) {
   } = useTokenMetaQuery(token.tokenID);
 
   const tokenAmountInCurrency = useTokenAmountInCurrency({
-    tokenAmount: Lisk.transactions.convertBeddowsToLSK(token.availableBalance),
+    tokenAmount: fromBaseToDisplayDenom({
+      amount: token.availableBalance,
+      displayDenom: token.displayDenom,
+      denomUnits: token.denomUnits,
+    }),
     tokenSymbol: tokenMetaData?.data[0]?.symbol,
   });
 

--- a/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
@@ -21,6 +21,7 @@ export function useApplicationSupportedTokensQuery(application) {
     isLoading: isAccountTokensFullDataLoading,
     isError: isAccountTokensFullDataError,
     error: errorOnAccountTokensFullData,
+    isSuccess: isSuccessAccountTokensFullData,
   } = useAccountTokensFullDataQuery();
 
   const {
@@ -28,6 +29,7 @@ export function useApplicationSupportedTokensQuery(application) {
     isLoading: isSupportedTokensLoading,
     isError: isSupportedTokensError,
     error: errorOnSupportedTokens,
+    isSuccess: isSuccessSupportedTokens,
   } = useSupportedTokensQuery({
     client: toApplicationApiClient.current,
   });
@@ -63,8 +65,9 @@ export function useApplicationSupportedTokensQuery(application) {
 
   return {
     data,
-    isError: isSupportedTokensError || isAccountTokensFullDataError,
     isLoading: isAccountTokensFullDataLoading || isSupportedTokensLoading,
+    isSuccess: isSuccessAccountTokensFullData && isSuccessSupportedTokens,
+    isError: isSupportedTokensError || isAccountTokensFullDataError,
     error: errorOnSupportedTokens || errorOnAccountTokensFullData,
     errorOnSupportedTokens,
     errorOnAccountTokensFullData,

--- a/src/modules/SendToken/components/SelectTokenStep/components.js
+++ b/src/modules/SendToken/components/SelectTokenStep/components.js
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import i18next from 'i18next';
-import * as Lisk from '@liskhq/lisk-client';
 
 import { useTheme } from 'contexts/ThemeContext';
 import { useApplicationSupportedTokensQuery } from 'modules/BlockchainApplication/api/useApplicationSupportedTokensQuery';
@@ -44,12 +43,16 @@ export function TokenSelectField({ value, onChange, recipientApplication, errorM
   const selectedToken = supportedTokensData?.find((token) => token.tokenID === value);
 
   const tokenBalance = selectedToken?.availableBalance
-    ? Number(
-        Lisk.transactions.convertBeddowsToLSK(selectedToken?.availableBalance)
-      ).toLocaleString()
+    ? fromBaseToDisplayDenom({
+        amount: selectedToken.availableBalance,
+        displayDenom: selectedToken.displayDenom,
+        denomUnits: selectedToken.denomUnits,
+        symbol: selectedToken.symbol,
+        withSymbol: true,
+      })
     : 0;
 
-  const MenuOptions = (data = supportedTokensData) => (
+  const renderOptions = (data = supportedTokensData) => (
     <InfiniteScrollList
       data={data}
       keyExtractor={(item) => item.tokenID}
@@ -65,7 +68,7 @@ export function TokenSelectField({ value, onChange, recipientApplication, errorM
     />
   );
 
-  const { showOptions } = Picker.usePickerMenu(<MenuOptions />);
+  const { showOptions } = Picker.usePickerMenu(renderOptions());
 
   return (
     <Picker value={value} error={errorMessage}>
@@ -77,9 +80,7 @@ export function TokenSelectField({ value, onChange, recipientApplication, errorM
         {selectedToken && (
           <Picker.Label style={style?.label}>
             {i18next.t('sendToken.tokenSelect.tokenIDBalanceLabel')}:{' '}
-            <Text style={[styles.primaryText]}>
-              {tokenBalance} {selectedToken.symbol}
-            </Text>
+            <Text style={[styles.primaryText]}>{tokenBalance}</Text>
           </Picker.Label>
         )}
       </View>

--- a/src/modules/SendToken/hooks/useSendTokenAmountChecker.js
+++ b/src/modules/SendToken/hooks/useSendTokenAmountChecker.js
@@ -1,7 +1,5 @@
-/* eslint-disable max-statements */
-import * as Lisk from '@liskhq/lisk-client';
-
 import { useApplicationSupportedTokensQuery } from 'modules/BlockchainApplication/api/useApplicationSupportedTokensQuery';
+import { fromDisplayToBaseDenom } from '../../../utilities/conversions.utils';
 
 export function useSendTokenAmountChecker({
   recipientApplication,
@@ -18,7 +16,15 @@ export function useSendTokenAmountChecker({
   const maxAllowedAmount = tokenBalance - transactionFee;
 
   const isMaxAllowedAmountExceeded =
-    maxAllowedAmount - BigInt(Lisk.transactions.convertLSKToBeddows(amount.toString())) <= 0;
+    maxAllowedAmount -
+      BigInt(
+        fromDisplayToBaseDenom({
+          amount,
+          displayDenom: selectedToken.displayDenom,
+          denomUnits: selectedToken.denomUnits,
+        })
+      ) <=
+    0;
 
   return { maxAllowedAmount, isMaxAllowedAmountExceeded };
 }

--- a/src/modules/SendToken/hooks/useSendTokenAmountChecker.js
+++ b/src/modules/SendToken/hooks/useSendTokenAmountChecker.js
@@ -17,13 +17,15 @@ export function useSendTokenAmountChecker({
 
   const isMaxAllowedAmountExceeded =
     maxAllowedAmount -
-      BigInt(
-        fromDisplayToBaseDenom({
-          amount,
-          displayDenom: selectedToken.displayDenom,
-          denomUnits: selectedToken.denomUnits,
-        })
-      ) <=
+      (selectedToken
+        ? BigInt(
+            fromDisplayToBaseDenom({
+              amount,
+              displayDenom: selectedToken.displayDenom,
+              denomUnits: selectedToken.denomUnits,
+            })
+          )
+        : BigInt(0)) <=
     0;
 
   return { maxAllowedAmount, isMaxAllowedAmountExceeded };

--- a/src/modules/SendToken/hooks/useSendTokenForm.js
+++ b/src/modules/SendToken/hooks/useSendTokenForm.js
@@ -49,7 +49,7 @@ export default function useSendTokenForm({ transaction, isTransactionSuccess, in
       recipientAccountAddress: initialValues?.recipientAccountAddress,
       recipientAccountAddressFormat: initialValues?.recipientAccountAddressFormat || 'input',
       tokenID: initialValues?.tokenID,
-      amount: initialValues?.amount ? BigInt(initialValues.amount) : 0,
+      amount: initialValues?.amount ? parseFloat(initialValues.amount) : 0,
       message: initialValues?.message || '',
       priority: 'low',
       userPassword: '',

--- a/src/modules/Transactions/__fixtures__/mockTransactions.js
+++ b/src/modules/Transactions/__fixtures__/mockTransactions.js
@@ -1,4 +1,4 @@
-import * as Lisk from '@liskhq/lisk-client';
+import { fromLskToBeddows } from 'utilities/conversions.utils';
 
 export const mockTransactions = [...new Array(10)].map((_, index) => ({
   id: `transaction${index}ID`,
@@ -14,7 +14,7 @@ export const mockTransactions = [...new Array(10)].map((_, index) => ({
   },
   params: {
     tokenID: '0400000000000000',
-    amount: Lisk.transactions.convertLSKToBeddows(index.toString()),
+    amount: fromLskToBeddows(index.toString()),
     recipientAddress: 'lsk2447tv63fubjrqpkfn7e9e3zhhwnuhzyhmvhqw',
     data: 'Test transaction',
   },

--- a/src/modules/Transactions/components/TransactionRow/TransactionRow.js
+++ b/src/modules/Transactions/components/TransactionRow/TransactionRow.js
@@ -5,12 +5,12 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useTheme } from 'contexts/ThemeContext';
 import { stringShortener } from 'utilities/helpers';
-import { fromRawLsk } from 'utilities/conversions.utils';
+import { fromBeddowsToLsk } from 'utilities/conversions.utils';
+import DiscreteModeComponent from 'components/shared/DiscreteModeComponent';
 import { useTransactionAssets } from '../../hooks/useTransactionAssets';
 import TransactionTimestamp from '../TransactionTimestamp';
 
 import getTransactionRowStyles from './TransactionRow.styles';
-import DiscreteModeComponent from '../../../../components/shared/DiscreteModeComponent';
 import { TransactionAmount } from './components/TransactionAmount';
 import { TransactionStatus } from './components/TransactionStatus';
 
@@ -59,12 +59,7 @@ export default function TransactionRow({ transaction, address }) {
       <View style={[styles.statusContainer, styles.theme.statusContainer]}>
         <DiscreteModeComponent
           blurVariant={blurVariant}
-          data={
-            transaction.notRawLisk
-              ? transaction.amount
-              : // eslint-disable-next-line no-undef
-                fromRawLsk(BigInt(transaction.params.amount ?? 0))
-          }
+          data={fromBeddowsToLsk(transaction.params.amount ?? 0)}
         >
           <TransactionAmount
             transaction={transaction}

--- a/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
+++ b/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
@@ -24,11 +24,10 @@ export function TransactionAmount({ transaction, style, address }) {
     transactionAssets.type === 'tokenTransfer' ||
     transactionAssets.type === 'tokenCrossChainTransfer';
 
-  if (!isTokenTransfer) {
-    return null;
-  }
-
-  if (transaction.params.recipientAddress === transaction.sender.address && !isTokenTransfer) {
+  if (
+    !isTokenTransfer ||
+    (transaction.params.recipientAddress === transaction.sender.address && !isTokenTransfer)
+  ) {
     return null;
   }
 

--- a/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
+++ b/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
@@ -24,10 +24,7 @@ export function TransactionAmount({ transaction, style, address }) {
     transactionAssets.type === 'tokenTransfer' ||
     transactionAssets.type === 'tokenCrossChainTransfer';
 
-  if (
-    !isTokenTransfer ||
-    (transaction.params.recipientAddress === transaction.sender.address && !isTokenTransfer)
-  ) {
+  if (!isTokenTransfer) {
     return null;
   }
 

--- a/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
+++ b/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
@@ -1,43 +1,57 @@
 import React from 'react';
-import { Text } from 'react-native';
+
 import { useSelector } from 'react-redux';
 
-import { fromRawLsk } from 'utilities/conversions.utils';
+import DataRenderer from 'components/shared/DataRenderer';
+import { P } from 'components/shared/toolBox/typography';
+import { fromBaseToDisplayDenom } from 'utilities/conversions.utils';
 import FormattedNumber from 'components/shared/formattedNumber';
+import { useTokenMetaQuery } from 'modules/BlockchainApplication/api/useTokenMetaQuery';
 import { useTransactionAssets } from '../../../hooks/useTransactionAssets';
-import { useTokenMetaQuery } from '../../../../BlockchainApplication/api/useTokenMetaQuery';
 
 export function TransactionAmount({ transaction, style, address }) {
-  const { data: tokenData } = useTokenMetaQuery(transaction.params.tokenID);
-  const tokenSymbol = tokenData?.data[0]?.symbol;
+  const {
+    data: tokenMetadata,
+    isLoading: isLoadingTokenMetadata,
+    error: errorOnTokenMetadata,
+  } = useTokenMetaQuery(transaction.params.tokenID);
+
   const transactionAssets = useTransactionAssets({ transaction, address });
+
   const language = useSelector((state) => state.settings.language);
 
-  const { sign } = transactionAssets.amount ?? {};
+  const isTokenTransfer =
+    transactionAssets.type === 'tokenTransfer' ||
+    transactionAssets.type === 'tokenCrossChainTransfer';
 
-  // Add fee to transaction amount shown on list for outgoing transactions
-  const rawLiskAmount =
-    sign === '-'
-      ? fromRawLsk((BigInt(transaction.params.amount) + BigInt(transaction.fee)).toString())
-      : fromRawLsk(BigInt(transaction.params.amount ?? 0).toString());
-
-  const transactionAmount = transaction.notRawLisk ? transaction.amount : rawLiskAmount;
-
-  if (
-    (transactionAssets.type === 'tokenTransfer' ||
-      transactionAssets.type === 'tokenCrossChainTransfer') &&
-    transaction.params.recipientAddress !== transaction.sender.address
-  ) {
-    return (
-      <Text style={[transactionAssets.amount.style, style]}>
-        {transactionAssets.amount.sign}
-
-        <FormattedNumber language={language} tokenType={tokenSymbol}>
-          {transactionAmount}
-        </FormattedNumber>
-      </Text>
-    );
+  if (transaction.params.recipientAddress === transaction.sender.address && !isTokenTransfer) {
+    return null;
   }
 
-  return null;
+  return (
+    <DataRenderer
+      data={tokenMetadata?.data}
+      isLoading={isLoadingTokenMetadata}
+      error={errorOnTokenMetadata}
+      renderData={(tokens) => {
+        const token = tokens[0];
+
+        const transactionAmount = fromBaseToDisplayDenom({
+          amount: transaction.params.amount,
+          displayDenom: token.displayDenom,
+          denomUnits: token.denomUnits,
+        });
+
+        return (
+          <P style={[transactionAssets.amount.style, style]}>
+            {transactionAssets.amount.sign}
+
+            <FormattedNumber language={language} tokenType={token?.symbol}>
+              {transactionAmount}
+            </FormattedNumber>
+          </P>
+        );
+      }}
+    />
+  );
 }

--- a/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
+++ b/src/modules/Transactions/components/TransactionRow/components/TransactionAmount.js
@@ -24,6 +24,10 @@ export function TransactionAmount({ transaction, style, address }) {
     transactionAssets.type === 'tokenTransfer' ||
     transactionAssets.type === 'tokenCrossChainTransfer';
 
+  if (!isTokenTransfer) {
+    return null;
+  }
+
   if (transaction.params.recipientAddress === transaction.sender.address && !isTokenTransfer) {
     return null;
   }
@@ -36,6 +40,10 @@ export function TransactionAmount({ transaction, style, address }) {
       renderData={(tokens) => {
         const token = tokens[0];
 
+        if (!token) {
+          return null;
+        }
+
         const transactionAmount = fromBaseToDisplayDenom({
           amount: transaction.params.amount,
           displayDenom: token.displayDenom,
@@ -43,10 +51,10 @@ export function TransactionAmount({ transaction, style, address }) {
         });
 
         return (
-          <P style={[transactionAssets.amount.style, style]}>
-            {transactionAssets.amount.sign}
+          <P style={[transactionAssets.amount?.style, style]}>
+            {transactionAssets.amount?.sign}
 
-            <FormattedNumber language={language} tokenType={token?.symbol}>
+            <FormattedNumber language={language} tokenType={token.symbol}>
               {transactionAmount}
             </FormattedNumber>
           </P>

--- a/src/utilities/conversions.utils.js
+++ b/src/utilities/conversions.utils.js
@@ -2,30 +2,6 @@ import { BigNumber } from 'bignumber.js';
 
 BigNumber.config({ ERRORS: false });
 
-export const fromRawLsk = (value) => {
-  const bgValue = new BigNumber(value || 0);
-  const factor = new BigNumber(10).pow(8);
-  const result = bgValue.dividedBy(factor).toFixed();
-  return result;
-};
-
-export const toRawLsk = (value) => {
-  const factor = new BigNumber(10).pow(8);
-  const rawValue = new BigNumber(value);
-  const bgRaw = rawValue.multipliedBy(factor);
-  return bgRaw.toFixed(0);
-};
-
-export const includeFee = (value, fee, asRawLsk = false) => {
-  const factor = new BigNumber(10).pow(8);
-  const bigValue = new BigNumber(value);
-  const rawValue = bigValue.multipliedBy(factor);
-  const bigFee = new BigNumber(fee);
-  const result = rawValue.plus(bigFee);
-  // eslint-disable-next-line no-undef
-  return asRawLsk ? result : fromRawLsk(BigInt(result ?? 0));
-};
-
 /**
  * Parses from base-denomination to display-denomination an amount of a given token.
  * @param {string} amount - Amount to convert (in base denomination).
@@ -118,3 +94,13 @@ export function fromLskToBeddows(amount) {
     denomUnits: [{ decimals: 8, denom: 'lsk' }],
   });
 }
+
+export const includeFee = (value, fee, asRawLsk = false) => {
+  const factor = new BigNumber(10).pow(8);
+  const bigValue = new BigNumber(value);
+  const rawValue = bigValue.multipliedBy(factor);
+  const bigFee = new BigNumber(fee);
+  const result = rawValue.plus(bigFee);
+  // eslint-disable-next-line no-undef
+  return asRawLsk ? result : fromBeddowsToLsk(BigInt(result ?? 0));
+};

--- a/src/utilities/conversions.utils.js
+++ b/src/utilities/conversions.utils.js
@@ -28,11 +28,11 @@ export const includeFee = (value, fee, asRawLsk = false) => {
 
 /**
  * Parses from base-denomination to display-denomination an amount of a given token.
- * @param {BigInt} amount - Amount to convert (in base denomination).
- * @param {String} displayDenom - Display denomination ID.
- * @param {Array.<{denom: String, decimals: Number}>} denomUnits - Denominations equivalence configs.
- * @param {String} symbol - Symbol of the token. Is added as suffix in the result if the param withSymbol=true.
- * @param {Boolean} withSymbol - Flag that indicates if the response should or not include the symbol of the
+ * @param {string} amount - Amount to convert (in base denomination).
+ * @param {string} displayDenom - Display denomination ID.
+ * @param {Array.<{denom: string, decimals: number}>} denomUnits - Denominations equivalence configs.
+ * @param {string} symbol - Symbol of the token. Is added as suffix in the result if the param withSymbol=true.
+ * @param {boolean} withSymbol - Flag that indicates if the response should or not include the symbol of the
  * token (optional, default: false).
  * @returns {string} Converted value in string format.
  */
@@ -65,11 +65,36 @@ export function fromBaseToDisplayDenom({
 }
 
 /**
- * Parses from base-denomination to display-denomination an amount of LSK.
- * @param {BigInt} amount - Amount to convert (in beddows).
- * @param {Boolean} withSymbol - Flag that indicates if the response should or not include the symbol of the
- * token (optional, default: false).
+ * Parses from display-denomination to base-denomination an amount of a given token.
+ * @param {string} amount - Amount to convert (in display denomination).
+ * @param {string} displayDenom - Display denomination ID.
+ * @param {Array.<{denom: string, decimals: number}>} denomUnits - Denominations equivalence configs.
  * @returns {string} Converted value in string format.
+ */
+export function fromDisplayToBaseDenom({ amount, displayDenom, denomUnits }) {
+  const bigAmount = new BigNumber(amount);
+
+  const conversionUnit = denomUnits.find((unit) => unit.denom === displayDenom);
+
+  if (!conversionUnit) {
+    throw new Error('Display denomination not found on units.');
+  }
+
+  const conversionDecimals = conversionUnit.decimals;
+
+  const conversionFactor = new BigNumber(10).pow(conversionDecimals);
+
+  const convertedAmount = bigAmount.multipliedBy(conversionFactor).toFixed();
+
+  return convertedAmount;
+}
+
+/**
+ * Parses from base-denomination to display-denomination an amount of LSK.
+ * @param {string} amount - Amount to convert (in beddows).
+ * @param {boolean} withSymbol - Flag that indicates if the response should or not include the symbol of the
+ * token (optional, default: false).
+ * @returns {string} Converted value in LSK.
  */
 export function fromBeddowsToLsk(amount, withSymbol = false) {
   return fromBaseToDisplayDenom({
@@ -78,5 +103,18 @@ export function fromBeddowsToLsk(amount, withSymbol = false) {
     denomUnits: [{ decimals: 8, denom: 'lsk' }],
     symbol: 'LSK',
     withSymbol,
+  });
+}
+
+/**
+ * Parses from display-denomination to base-denomination an amount of LSK.
+ * @param {string} amount - Amount to convert (in LSK).
+ * @returns {string} Converted value in beddows.
+ */
+export function fromLskToBeddows(amount) {
+  return fromDisplayToBaseDenom({
+    amount,
+    displayDenom: 'lsk',
+    denomUnits: [{ decimals: 8, denom: 'lsk' }],
   });
 }

--- a/src/utilities/conversions.utils.test.js
+++ b/src/utilities/conversions.utils.test.js
@@ -1,9 +1,14 @@
-import { fromBaseToDisplayDenom, fromBeddowsToLsk } from './conversions.utils';
+import {
+  fromBaseToDisplayDenom,
+  fromDisplayToBaseDenom,
+  fromBeddowsToLsk,
+  fromLskToBeddows,
+} from './conversions.utils';
 
 describe('conversion utils', () => {
-  describe('fromBaseToDisplayDenom util', () => {
+  describe('fromBaseToDisplayDenom', () => {
     const baseProps = {
-      amount: BigInt(5000000),
+      amount: '5000000',
       symbol: 'LSK',
       displayDenom: 'lsk',
       baseDenom: 'beddows',
@@ -40,19 +45,69 @@ describe('conversion utils', () => {
     });
   });
 
-  describe('fromBeddowsToLsk util', () => {
+  describe('fromDisplayToBaseDenom', () => {
+    const denomUnits = [
+      {
+        denom: 'beddows',
+        decimals: 0,
+        aliases: ['Beddows'],
+      },
+      {
+        denom: 'lsk',
+        decimals: 8,
+        aliases: ['Lisk'],
+      },
+    ];
+
+    it('should convert from display to base denomination correctly', () => {
+      const displayAmount = '0.05';
+      const displayDenom = 'lsk';
+
+      const result = fromDisplayToBaseDenom({
+        amount: displayAmount,
+        displayDenom,
+        denomUnits,
+      });
+
+      expect(result).toEqual('5000000');
+    });
+
+    it('should throw an error if display denomination is not found', () => {
+      const displayAmount = '0.05';
+      const displayDenom = 'nonexistent';
+
+      expect(() => {
+        fromDisplayToBaseDenom({
+          amount: displayAmount,
+          displayDenom,
+          denomUnits,
+        });
+      }).toThrow('Display denomination not found on units.');
+    });
+  });
+
+  describe('fromBeddowsToLsk', () => {
     it('parses correctly a given amount from Beddows to LSK', () => {
-      const paramAmount = BigInt(5000000);
+      const paramAmount = '5000000';
       const expectedAmount = '0.05';
 
       expect(fromBeddowsToLsk(paramAmount)).toBe(expectedAmount);
     });
 
     it('adds the token symbol if specified on props', () => {
-      const paramAmount = BigInt(1000000);
+      const paramAmount = '1000000';
       const expectedAmount = '0.01 LSK';
 
       expect(fromBeddowsToLsk(paramAmount, true)).toBe(expectedAmount);
+    });
+  });
+
+  describe('fromLskToBeddows', () => {
+    it('parses correctly a given amount from LSK to Beddows', () => {
+      const paramAmount = '0.05';
+      const expectedAmount = '5000000';
+
+      expect(fromLskToBeddows(paramAmount)).toBe(expectedAmount);
     });
   });
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #1733 and #1722

### How was it solved?

- [x] Add `fromDisplayToBaseDenom` and `fromLskToBeddows` helpers.
- [x] Calculate tx amount dynamically with `fromDisplayToBaseDenom` on token:transfer form. Passed from statically calculating the amount (with `Lisk.transactions.convertLSKToBeddows`) to calculate them dynamically considering the selected token.
- [x] Fix app breaking on open token picker.
- [x] Calculate dynamically in all application the fee and amounts tokens.
- [x] Remove unused "Confirmations" field on transaction details screen.
- [x] Fix transaction amount rendering for non-transfer transactions.
- [x] Fix receive token amount missmatching.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
