### PR TITLE
Fix app crashes when a transaction is invalid

### DIFF
--- a/src/modules/SendToken/components/SummaryStep/index.js
+++ b/src/modules/SendToken/components/SummaryStep/index.js
@@ -74,7 +74,7 @@ export default function SendTokenSummaryStep({ form, prevStep, transaction, rese
       summary.token,
       form.isSuccess,
       form.isLoading,
-      form.error,
+      form.isError,
     ]
   );
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #1751 

### How was it solved?

- [x] Listen to `isError` instead of `error` on token:transfer sign tx modal. With this, the infinite loop on dryrun error is fixed

### How was it tested?
- [x] iOS Simulator.
- [x] Android emulator.

https://user-images.githubusercontent.com/9727036/232732986-58c0102c-a6af-494a-8b2f-49ae16cff411.mp4



