### PR TITLE
Fix balance not updated on accounts when entering to the account details from another logged in account

### DIFF
--- a/src/modules/Accounts/api/useAccountTokensFullDataQuery.js
+++ b/src/modules/Accounts/api/useAccountTokensFullDataQuery.js
@@ -1,4 +1,3 @@
-import { useCurrentAccount } from 'modules/Accounts/hooks/useCurrentAccount';
 import { useCustomInfiniteQuery } from 'utilities/api/hooks/useCustomInfiniteQuery';
 import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 import { LIMIT, API_URL } from 'utilities/api/constants';
@@ -7,14 +6,16 @@ import { addTokensMetaData } from '../utils/accounts.utils';
 
 /**
  * Fetches off-chain and on-chain tokens data and merge them together.
+ * @param {String} address - Address of the account to fetch the tokens from.
  * @param {Object} config - Custom configurations for the query.
  * @param {Object} options - Custom options for the query.
  * @returns {Object} The query state of the API call. Includes the data
  * (tokens full data), loading state, error state, and more.
  */
-export function useAccountTokensFullDataQuery({ config: customConfig = {}, options = {} } = {}) {
-  const [currentAccount] = useCurrentAccount();
-
+export function useAccountTokensFullDataQuery(
+  address,
+  { config: customConfig = {}, options = {} } = {}
+) {
   const transformTokensResult = async (res) => {
     const tokensData = await addTokensMetaData(res.data);
 
@@ -30,25 +31,18 @@ export function useAccountTokensFullDataQuery({ config: customConfig = {}, optio
     event: 'get.token.balances',
     ...customConfig,
     params: {
-      address: currentAccount?.metadata?.address,
+      address,
       limit: LIMIT,
       ...(customConfig?.params || {}),
     },
     transformResult: transformTokensResult,
   };
 
-  const keys = useQueryKeys([
-    GET_ACCOUNT_TOKENS_FULL_DATA_QUERY,
-    currentAccount?.metadata?.address,
-    config,
-  ]);
+  const keys = useQueryKeys([GET_ACCOUNT_TOKENS_FULL_DATA_QUERY, address, config]);
 
   return useCustomInfiniteQuery({
-    keys: [...keys],
+    keys,
     config,
-    options: {
-      ...options,
-      enabled: !!currentAccount?.metadata,
-    },
+    options,
   });
 }

--- a/src/modules/Accounts/components/AccountHome/AccountHome.js
+++ b/src/modules/Accounts/components/AccountHome/AccountHome.js
@@ -30,17 +30,14 @@ function AccountHome() {
   const [currentAccount] = useCurrentAccount();
 
   const { refetch: refetchTokens, isRefetching: isRefetchingTokens } =
-    useAccountTokensFullDataQuery(currentAccount?.metadata.address, {
+    useAccountTokensFullDataQuery(currentAccount.metadata.address, {
       config: {
         params: { limit: NO_OF_TOKENS_ON_OVERVIEW },
-      },
-      options: {
-        enabled: !!currentAccount?.metadata,
       },
     });
 
   const { refetch: refetchTransactions, isRefetching: isRefetchingTransactions } =
-    useAccountTransactionsQuery(currentAccount?.metadata.address, {
+    useAccountTransactionsQuery(currentAccount.metadata.address, {
       config: {
         params: { limit: NO_OF_TRANSACTIONS_ON_OVERVIEW },
       },

--- a/src/modules/Accounts/components/AccountHome/AccountHome.js
+++ b/src/modules/Accounts/components/AccountHome/AccountHome.js
@@ -30,9 +30,12 @@ function AccountHome() {
   const [currentAccount] = useCurrentAccount();
 
   const { refetch: refetchTokens, isRefetching: isRefetchingTokens } =
-    useAccountTokensFullDataQuery({
+    useAccountTokensFullDataQuery(currentAccount?.metadata.address, {
       config: {
         params: { limit: NO_OF_TOKENS_ON_OVERVIEW },
+      },
+      options: {
+        enabled: !!currentAccount?.metadata,
       },
     });
 

--- a/src/modules/Accounts/components/AccountHome/AccountHome.js
+++ b/src/modules/Accounts/components/AccountHome/AccountHome.js
@@ -40,7 +40,7 @@ function AccountHome() {
     });
 
   const { refetch: refetchTransactions, isRefetching: isRefetchingTransactions } =
-    useAccountTransactionsQuery(currentAccount.metadata.address, {
+    useAccountTransactionsQuery(currentAccount?.metadata.address, {
       config: {
         params: { limit: NO_OF_TRANSACTIONS_ON_OVERVIEW },
       },

--- a/src/modules/Accounts/components/TokenList/TokenList.js
+++ b/src/modules/Accounts/components/TokenList/TokenList.js
@@ -39,7 +39,7 @@ export default function TokenList({ mode = 'overview', address, style }) {
     fetchNextPage: fetchNextTokensPage,
     hasNextPage: hasTokensNextPage,
     isFetchingNextPage: isFetchingTokensNextPage,
-  } = useAccountTokensFullDataQuery({
+  } = useAccountTokensFullDataQuery(address, {
     config: {
       params: { limit: mode === 'overview' ? NO_OF_TOKENS_ON_OVERVIEW : LIMIT },
     },

--- a/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
@@ -1,8 +1,9 @@
 import { useMemo, useRef } from 'react';
 
+import { useCurrentAccount } from 'modules/Accounts/hooks/useCurrentAccount';
+import { useAccountTokensFullDataQuery } from 'modules/Accounts/api/useAccountTokensFullDataQuery';
 import { APIClient } from 'utilities/api/APIClient';
 import { useSupportedTokensQuery } from './useSupportedTokensQuery';
-import { useAccountTokensFullDataQuery } from '../../Accounts/api/useAccountTokensFullDataQuery';
 
 /**
  * Fetch list of supported tokens for a given account and blockchain application.
@@ -16,13 +17,19 @@ export function useApplicationSupportedTokensQuery(application) {
 
   toApplicationApiClient.current.create(application?.serviceURLs[0]);
 
+  const [currentAccount] = useCurrentAccount;
+
   const {
     data: { data: accountTokensFullData } = {},
     isLoading: isAccountTokensFullDataLoading,
     isError: isAccountTokensFullDataError,
     error: errorOnAccountTokensFullData,
     isSuccess: isSuccessAccountTokensFullData,
-  } = useAccountTokensFullDataQuery();
+  } = useAccountTokensFullDataQuery(currentAccount?.metadata.address, {
+    options: {
+      enabled: !!currentAccount?.metadata,
+    },
+  });
 
   const {
     data: { data: { supportedTokens: supportedTokensData } = {} } = {},

--- a/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
@@ -17,7 +17,7 @@ export function useApplicationSupportedTokensQuery(application) {
 
   toApplicationApiClient.current.create(application?.serviceURLs[0]);
 
-  const [currentAccount] = useCurrentAccount;
+  const [currentAccount] = useCurrentAccount();
 
   const {
     data: { data: accountTokensFullData } = {},

--- a/src/modules/BlockchainApplication/api/useTokensMetaQuery.js
+++ b/src/modules/BlockchainApplication/api/useTokensMetaQuery.js
@@ -1,6 +1,6 @@
 import { useCustomInfiniteQuery } from 'utilities/api/hooks/useCustomInfiniteQuery';
 import { GET_TOKENS_METADATA_QUERY } from 'utilities/api/queries';
-import { LIMIT, API_URL, NETWORK } from 'utilities/api/constants';
+import { LIMIT, API_URL } from 'utilities/api/constants';
 import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 import liskAPIClient from 'utilities/api/LiskAPIClient';
 
@@ -10,7 +10,7 @@ export function getTokensMetaQueryConfig(customConfig = {}) {
     method: 'get',
     event: 'get.blockchain.apps.meta.tokens',
     ...customConfig,
-    params: { network: NETWORK, limit: LIMIT, ...customConfig.params },
+    params: { limit: LIMIT, ...customConfig.params },
   };
 }
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #1793

### How was it solved?

- [x] Make `useAccountTokensFullDataQuery` query be account agnostic. Allow to pass dynamically any address to query tokens from.
- [x] Remove network param from token queries when ID is provided.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
