### PR TITLE
Fix WalletConnect sign transaction event doesn't trigger after consecutive requests

### DIFF
--- a/libs/wcm/context/connectionProvider.js
+++ b/libs/wcm/context/connectionProvider.js
@@ -19,6 +19,7 @@ const ConnectionProvider = ({ children }) => {
 
   const removeEvent = (event) => {
     const newEvents = events.filter((e) => e.name !== event.name);
+
     setEvents(newEvents);
   };
 

--- a/libs/wcm/hooks/useConnectionEventsManager.js
+++ b/libs/wcm/hooks/useConnectionEventsManager.js
@@ -30,13 +30,13 @@ const useWalletConnectEventsManager = () => {
   }, []);
 
   useEffect(() => {
-    if (signClient?.on) {
+    if (signClient) {
       Object.keys(EVENTS).forEach((eventName) => {
         signClient.on(EVENTS[eventName], eventHandler.bind(null, EVENTS[eventName]));
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onSessionRequest, onSessionDelete, eventHandler, signClient?.on]);
+  }, [onSessionRequest, onSessionDelete, eventHandler, signClient]);
 };
 
 export default useWalletConnectEventsManager;

--- a/libs/wcm/hooks/useSession.js
+++ b/libs/wcm/hooks/useSession.js
@@ -63,6 +63,7 @@ const useSession = () => {
         topic,
         response,
       });
+
       return {
         status: STATUS.SUCCESS,
         data,

--- a/libs/wcm/hooks/useSession.js
+++ b/libs/wcm/hooks/useSession.js
@@ -14,6 +14,7 @@ const useSession = () => {
 
   const approve = useCallback(async (selectedAccounts) => {
     const proposalEvents = events.find((e) => e.name === EVENTS.SESSION_PROPOSAL);
+
     try {
       await setSession({
         ...session,
@@ -37,8 +38,9 @@ const useSession = () => {
 
   const reject = useCallback(async () => {
     const proposalEvents = events.find((e) => e.name === EVENTS.SESSION_PROPOSAL);
+
     try {
-      setSession({ ...session, request: false });
+      await setSession({ ...session, request: false });
       await onReject(proposalEvents.meta);
       removeEvent(proposalEvents);
       return {
@@ -59,6 +61,8 @@ const useSession = () => {
     const response = formatJsonRpcResult(requestEvent.meta.id, payload);
 
     try {
+      await setSession({ ...session, request: false });
+
       const data = await signClient.respond({
         topic,
         response,

--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -338,6 +338,7 @@
         "continueButtonText": "Zustimmen"
       },
       "sign": {
+        "submitButtonTitle": "Bestätigen und unterschreiben",
         "copyToClipboardButtonText": "Kopieren und zur App-Site weiterleiten",
         "copiedToClipboardButtonText": "Kopiert",
         "errorButtonText": "Weiterleitung zur App-Site"

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -336,6 +336,7 @@
         "continueButtonText": "Approve"
       },
       "sign": {
+        "submitButtonTitle": "Confirm and sign",
         "copyToClipboardButtonText": "Copy and redirect to application site",
         "copiedToClipboardButtonText": "Copied",
         "errorButtonText": "Redirect to application site"

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/ExternalAppSignatureRequestSignTransaction.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/ExternalAppSignatureRequestSignTransaction.js
@@ -43,6 +43,9 @@ export default function ExternalAppSignatureRequestSignTransaction({
       isLoading={isLoading}
       isValidationError={Object.keys(passwordForm.formState.errors).length > 0}
       error={error}
+      submitButtonTitle={i18next.t(
+        'application.externalApplicationSignatureRequest.sign.submitButtonTitle'
+      )}
       successActionButton={
         <PrimaryButton onClick={handleSuccessSubmit}>
           {!isSignedTransactionCopiedToClipboard

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/ExternalAppSignatureRequestSignTransaction.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/ExternalAppSignatureRequestSignTransaction.js
@@ -12,6 +12,7 @@ export default function ExternalAppSignatureRequestSignTransaction({
   session,
   transaction,
   onSubmit,
+  onClose,
   isSuccess,
   isLoading,
   error,
@@ -28,6 +29,7 @@ export default function ExternalAppSignatureRequestSignTransaction({
 
   const handleSuccessSubmit = () => {
     handleCopySignedTransactionToClipboard();
+    onClose();
     Linking.openURL(session.peer.metadata.url);
   };
   const handleErrorSubmit = () => Linking.openURL(session.peer.metadata.url);

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
@@ -35,8 +35,6 @@ export default function ExternalApplicationSignatureRequest({ session, onClose, 
     [event.meta.params.request.params.payload]
   );
 
-  console.log(event.meta.params.request.params.payload);
-
   const transaction = useCreateTransaction(createTransactionOptions);
 
   const senderAccountAddress = extractAddressFromPublicKey(session.peer.publicKey);

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
@@ -26,7 +26,7 @@ export default function ExternalApplicationSignatureRequest({ session, onClose, 
 
   const { events } = useContext(WalletConnectContext);
 
-  const event = events.find((e) => e.name === EVENTS.SESSION_REQUEST);
+  const event = useMemo(() => events.find((e) => e.name === EVENTS.SESSION_REQUEST), []);
 
   const createTransactionOptions = useMemo(
     () => ({

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/index.js
@@ -16,7 +16,7 @@ import ExternalAppSignatureRequestSummary from './ExternalAppSignatureRequestSum
 import ExternalAppSignatureRequestNotification from './ExternalAppSignatureRequestNotification';
 import ExternalAppSignatureRequestSignTransaction from './ExternalAppSignatureRequestSignTransaction';
 
-export default function ExternalApplicationSignatureRequest({ session, onCancel }) {
+export default function ExternalApplicationSignatureRequest({ session, onClose, onCancel }) {
   const [status, setStatus] = useState({});
   const [activeStep, setActiveStep] = useState('notification');
 
@@ -34,6 +34,8 @@ export default function ExternalApplicationSignatureRequest({ session, onCancel 
     }),
     [event.meta.params.request.params.payload]
   );
+
+  console.log(event.meta.params.request.params.payload);
 
   const transaction = useCreateTransaction(createTransactionOptions);
 
@@ -115,6 +117,7 @@ export default function ExternalApplicationSignatureRequest({ session, onCancel 
             session={session}
             transaction={_transaction}
             onSubmit={handleSubmit}
+            onClose={onClose}
             isSuccess={status.isSuccess}
             isLoading={status.isLoading}
             error={status.error}

--- a/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/styles.js
+++ b/src/modules/BlockchainApplication/components/ExternalApplicationSignatureRequest/styles.js
@@ -70,6 +70,7 @@ export default {
     },
     buttonContainer: {
       flexDirection: 'row',
+      paddingTop: boxes.boxPadding,
       paddingBottom: boxes.boxPadding,
     },
     button: {

--- a/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
+++ b/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
@@ -1,12 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
 
 import { useModal } from 'hooks/useModal';
 import ExternalApplicationSignatureRequest from 'modules/BlockchainApplication/components/ExternalApplicationSignatureRequest';
 import useWalletConnectSession from '../../../../libs/wcm/hooks/useSession';
+import WalletConnectContext from '../../../../libs/wcm/context/connectionContext';
+import { EVENTS } from '../../../../libs/wcm/constants/lifeCycle';
 
 export function useExternalApplicationSignatureRequest() {
   const { session, reject } = useWalletConnectSession();
+  const { events } = useContext(WalletConnectContext);
+
+  const event = events.find((e) => e.name === EVENTS.SESSION_REQUEST);
 
   const navigation = useNavigation();
 
@@ -27,9 +32,8 @@ export function useExternalApplicationSignatureRequest() {
           onClose={handleClose}
           onCancel={handleRejectRequest}
           navigation={navigation}
-        />,
-        true
+        />
       );
     }
-  }, [session.request]);
+  }, [session.request, event?.meta.id]);
 }

--- a/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
+++ b/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
@@ -13,16 +13,19 @@ export function useExternalApplicationSignatureRequest() {
   const modal = useModal();
 
   useEffect(() => {
-    const rejectRequest = () => {
+    const handleRejectRequest = () => {
       reject();
       modal.close();
     };
+
+    const handleClose = () => modal.close();
 
     if (session.request) {
       modal.open(
         <ExternalApplicationSignatureRequest
           session={session.request}
-          onCancel={rejectRequest}
+          onClose={handleClose}
+          onCancel={handleRejectRequest}
           navigation={navigation}
         />,
         true

--- a/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
+++ b/src/modules/BlockchainApplication/hooks/useExternalApplicationSignatureRequest.js
@@ -10,12 +10,10 @@ import { EVENTS } from '../../../../libs/wcm/constants/lifeCycle';
 export function useExternalApplicationSignatureRequest() {
   const { session, reject } = useWalletConnectSession();
   const { events } = useContext(WalletConnectContext);
+  const navigation = useNavigation();
+  const modal = useModal();
 
   const event = events.find((e) => e.name === EVENTS.SESSION_REQUEST);
-
-  const navigation = useNavigation();
-
-  const modal = useModal();
 
   useEffect(() => {
     const handleRejectRequest = () => {
@@ -25,7 +23,7 @@ export function useExternalApplicationSignatureRequest() {
 
     const handleClose = () => modal.close();
 
-    if (session.request) {
+    if (session.request && event?.meta.id) {
       modal.open(
         <ExternalApplicationSignatureRequest
           session={session.request}

--- a/src/modules/Transactions/components/ConfirmTransaction/index.js
+++ b/src/modules/Transactions/components/ConfirmTransaction/index.js
@@ -22,6 +22,7 @@ export default function ConfirmTransaction({
   isLoading,
   isValidationError,
   onSubmit,
+  submitButtonTitle,
 }) {
   const [currentAccount] = useCurrentAccount();
   const { sensorType, biometricsEnabled } = useSelector((state) => state.settings);
@@ -37,7 +38,7 @@ export default function ConfirmTransaction({
     return accountPassword;
   };
 
-  const fetchAccontPasswordFromBiometrics = async () => {
+  const fetchAccountPasswordFromBiometrics = async () => {
     if (sensorType && biometricsEnabled) {
       const accountPassword = await fetchAccountPassword();
       if (accountPassword) {
@@ -53,7 +54,7 @@ export default function ConfirmTransaction({
 
   useEffect(() => {
     if (sensorType && biometricsEnabled) {
-      fetchAccontPasswordFromBiometrics();
+      fetchAccountPasswordFromBiometrics();
     }
   }, [sensorType]);
 
@@ -114,7 +115,7 @@ export default function ConfirmTransaction({
         >
           {isLoading
             ? i18next.t('sendToken.confirmAndSign.loadingText')
-            : i18next.t('sendToken.confirmAndSign.sendTokenSubmitButtonText')}
+            : submitButtonTitle || i18next.t('sendToken.confirmAndSign.sendTokenSubmitButtonText')}
         </PrimaryButton>
       </View>
     </View>

--- a/src/modules/Transactions/components/SignTransaction/SignTransaction.js
+++ b/src/modules/Transactions/components/SignTransaction/SignTransaction.js
@@ -6,6 +6,7 @@ import SignTransactionSuccess from './SignTransactionSuccess';
 
 export default function SignTransaction({
   isValidationError,
+  submitButtonTitle,
   successActionButton,
   successTitle,
   successDescription,
@@ -59,6 +60,7 @@ export default function SignTransaction({
           onUserPasswordChange={onUserPasswordChange}
           isLoading={isLoading}
           isValidationError={isValidationError}
+          submitButtonTitle={submitButtonTitle}
         />
       );
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #1797

### How was it solved?

- [x] Close external application connection modal before redirection
- [x] Fix external app request modal open. Now listening for events change when opening the modal

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.

https://user-images.githubusercontent.com/9727036/236201531-1ccd39b3-7dbf-4105-90d0-f905d9ffc37d.mov