### PR TITLE
Fix recipient address field of token:transfer form haves wrong placeholder text

### DIFF
--- a/locales/resources/de.json
+++ b/locales/resources/de.json
@@ -365,7 +365,7 @@
       "recipientApplicationFieldLabel": "Zur App",
       "recipientApplicationFieldPlaceholder": "Wählen Sie eine App aus",
       "recipientAccountFieldLabel": "Empfänger:in",
-      "addressPlaceholder": "Input address",
+      "addressPlaceholder": "Adresse eingeben",
       "nextStepButtonText": "Weiter"
     },
     "tokenSelect": {

--- a/locales/resources/en.json
+++ b/locales/resources/en.json
@@ -363,7 +363,7 @@
       "recipientApplicationFieldLabel": "To application",
       "recipientApplicationFieldPlaceholder": "Select an application",
       "recipientAccountFieldLabel": "Recipient",
-      "addressPlaceholder": "Input address",
+      "addressPlaceholder": "Enter address",
       "nextStepButtonText": "Continue"
     },
     "tokenSelect": {


### PR DESCRIPTION
### What was the problem?

This PR resolves #1800

### How was it solved?

- [x] Fix recipient address input placeholder text on token:transfer form

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.

![simulator_screenshot_CF604B39-2F81-485C-9744-9D09867CCB32](https://user-images.githubusercontent.com/9727036/236203719-f7d7bc9f-17f7-4149-9a6b-1e4af48b6c45.png)
