### PR TITLE
Remove `network` query param from queries that specify the resource ID

### DIFF
--- a/src/modules/BlockchainApplication/hooks/useApplicationsLocalStorage.js
+++ b/src/modules/BlockchainApplication/hooks/useApplicationsLocalStorage.js
@@ -29,7 +29,6 @@ export function useApplicationsLocalStorage() {
     event: 'get.blockchain.apps.meta',
     transformResult: transformApplicationsMetaQueryResult,
     params: {
-      network: process.env.NETWORK,
       chainID: localStorageData && localStorageData.join(','),
     },
   };


### PR DESCRIPTION
### What was the problem?

This PR resolves #1812

### How was it solved?

- [x] Remove network query param from queries that specify the resource ID

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.
