### PR TITLE
Fix incognito mode shows blurred amounts for transactions without amount

### DIFF
--- a/src/modules/Transactions/components/TransactionRow/TransactionRow.js
+++ b/src/modules/Transactions/components/TransactionRow/TransactionRow.js
@@ -57,16 +57,18 @@ export default function TransactionRow({ transaction, address }) {
       </View>
 
       <View style={[styles.statusContainer, styles.theme.statusContainer]}>
-        <DiscreteModeComponent
-          blurVariant={blurVariant}
-          data={fromBeddowsToLsk(transaction.params.amount ?? 0)}
-        >
-          <TransactionAmount
-            transaction={transaction}
-            address={address}
-            style={{ marginBottom: 4 }}
-          />
-        </DiscreteModeComponent>
+        {transaction.params.amount && (
+          <DiscreteModeComponent
+            blurVariant={blurVariant}
+            data={fromBeddowsToLsk(transaction.params.amount)}
+          >
+            <TransactionAmount
+              transaction={transaction}
+              address={address}
+              style={{ marginBottom: 4 }}
+            />
+          </DiscreteModeComponent>
+        )}
 
         <TransactionStatus transaction={transaction} />
       </View>


### PR DESCRIPTION
### What was the problem?

This PR resolves #1814

### How was it solved?

- [x] Render tx amount over `DiscreteModeComponent` only when it exists.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.