### PR TITLE
Fix current account once removed is not reset

### DIFF
--- a/src/modules/Accounts/components/DeleteAccountForm/index.js
+++ b/src/modules/Accounts/components/DeleteAccountForm/index.js
@@ -31,13 +31,13 @@ export default function DeleteAccountForm({ mode, account, onCompleted, style })
 
   const { styles } = useTheme({ styles: getDeleteAccountFormStyles() });
 
-  function handleDelete() {
+  const handleSubmit = () => {
     deleteAccount(account.metadata.address);
 
     if (onCompleted) {
       onCompleted();
     }
-  }
+  };
 
   return (
     <View style={[styles.container, style?.container]} testID="delete-account-container">
@@ -76,7 +76,7 @@ export default function DeleteAccountForm({ mode, account, onCompleted, style })
       </View>
 
       <PrimaryButton
-        onPress={handleDelete}
+        onPress={handleSubmit}
         title={i18next.t('accounts.accountsManager.deleteAccountButtonText')}
         disabled={!isSuccessDownloadFile}
         style={[styles.submitButton, style?.submitButton]}

--- a/src/modules/Accounts/hooks/useAccountManagerModal.js
+++ b/src/modules/Accounts/hooks/useAccountManagerModal.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import React, { useEffect, useState } from 'react';
 
 import { useModal } from 'hooks/useModal';
@@ -6,6 +7,7 @@ import { useNavigation } from '@react-navigation/native';
 import AccountList from '../components/AccountList';
 import EditAccountForm from '../components/EditAccountForm';
 import DeleteAccountForm from '../components/DeleteAccountForm';
+import { useCurrentAccount } from './useCurrentAccount';
 
 export default function useAccountManagerModal() {
   const [data, setData] = useState(undefined);
@@ -14,11 +16,24 @@ export default function useAccountManagerModal() {
 
   const navigation = useNavigation();
 
-  function handleCompleted() {
-    navigation.navigate('Main');
+  const [currentAccount] = useCurrentAccount();
+
+  const handleOnDeleteCompleted = () => {
     modal.close();
     setActiveScreen(undefined);
-  }
+
+    if (data?.metadata.address === currentAccount?.metadata.address) {
+      navigation.navigate('AccountsManagerScreen');
+    } else {
+      navigation.navigate('Main');
+    }
+  };
+
+  const handleOnEditCompleted = () => {
+    modal.close();
+    setActiveScreen(undefined);
+    navigation.navigate('Main');
+  };
 
   const changeSelection = (selection, account) => {
     setData(account);
@@ -42,11 +57,15 @@ export default function useAccountManagerModal() {
         break;
 
       case 'EditAccount':
-        children = <EditAccountForm mode="modal" account={data} onCompleted={handleCompleted} />;
+        children = (
+          <EditAccountForm mode="modal" account={data} onCompleted={handleOnEditCompleted} />
+        );
         break;
 
       case 'DeleteAccount':
-        children = <DeleteAccountForm mode="modal" account={data} onCompleted={handleCompleted} />;
+        children = (
+          <DeleteAccountForm mode="modal" account={data} onCompleted={handleOnDeleteCompleted} />
+        );
         break;
 
       default:

--- a/src/modules/Accounts/hooks/useAccountManagerModal.js
+++ b/src/modules/Accounts/hooks/useAccountManagerModal.js
@@ -24,15 +24,12 @@ export default function useAccountManagerModal() {
 
     if (data?.metadata.address === currentAccount?.metadata.address) {
       navigation.navigate('AccountsManagerScreen');
-    } else {
-      navigation.navigate('Main');
     }
   };
 
   const handleOnEditCompleted = () => {
     modal.close();
     setActiveScreen(undefined);
-    navigation.navigate('Main');
   };
 
   const changeSelection = (selection, account) => {

--- a/src/modules/Auth/components/AuthMethod/index.js
+++ b/src/modules/Auth/components/AuthMethod/index.js
@@ -64,7 +64,7 @@ export default function AuthMethod({ route }) {
     } else {
       navigation.push('Intro');
     }
-  }, [accounts.length, settings.showedIntro]);
+  }, [settings.showedIntro]);
 
   const checkVersion2Migration = async () => {
     const { password: recoveryPhrase } = await getRecoveryPhraseFromKeyChain();


### PR DESCRIPTION
### What was the problem?

This PR resolves #1834

### How was it solved?

- [x] Remove accounts length dependency from auth method effect.
- [x] Check for currentAccount before redirecting on delete account. Now redirecting to accounts management if deleted account is the current account.
- [x] Rename handle submit function of DeleteAccountForm to a more semantic one.

### How was it tested?

- [x] iOS Simulator.
- [x] Android Emulator.


https://github.com/LiskHQ/lisk-mobile/assets/9727036/78d1a2bd-8cbf-495f-ae3c-0b6ed3bc63b6

