### PR TITLE
Use Android `android:dataExtractionRules` rule to control what data is transferred between Android devices

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,7 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application android:usesCleartextTraffic="false" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+    <application android:usesCleartextTraffic="false"
+        tools:targetApi="28"
+        tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,7 +42,5 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
-
   </application>
-
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,8 +20,7 @@
     android:theme="@style/AppTheme"
     android:allowTaskReparenting="false"
     android:taskAffinity=""
-    android:usesCleartextTraffic="false"
-    android:taskAffinity="">
+    android:usesCleartextTraffic="false">
     <activity android:name=".MainActivity"
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,46 +2,47 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="io.lisk.mobile">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission tools:node="merge" android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission tools:node="merge"
+    android:name="android.permission.READ_PHONE_STATE" />
+  <uses-permission android:name="android.permission.VIBRATE" />
 
-    <application
-      android:name=".MainApplication"
+  <application android:name=".MainApplication"
+    android:label="@string/app_name"
+    android:icon="@mipmap/ic_launcher"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:allowBackup="false"
+    android:fullBackupContent="false"
+    android:dataExtractionRules="@xml/data_extraction_rules"
+    android:theme="@style/AppTheme"
+    android:allowTaskReparenting="false"
+    android:taskAffinity=""
+    android:usesCleartextTraffic="false"
+    android:taskAffinity="">
+    <activity android:name=".MainActivity"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:allowTaskReparenting="false"
-      android:taskAffinity=""
-      android:usesCleartextTraffic="false">
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustPan"
-        android:screenOrientation="portrait"
-        android:exported="true">
-       <intent-filter android:autoVerify="true">
-          <action android:name="android.intent.action.VIEW" />
-          <category android:name="android.intent.category.DEFAULT" />
-          <category android:name="android.intent.category.BROWSABLE" />
-          <data
-            android:scheme="https"
-            android:host="lisk.com"
-            android:pathPrefix="/wallet" />
-        </intent-filter>
-        <intent-filter>
-          <action android:name="android.intent.action.MAIN" />
-          <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+      android:launchMode="singleTask"
+      android:windowSoftInputMode="adjustPan"
+      android:screenOrientation="portrait"
+      android:exported="true">
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https"
+          android:host="lisk.com"
+          android:pathPrefix="/wallet" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
 
-    </application>
+  </application>
 
 </manifest>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,17 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <data-extraction-rules>
-    <cloud-backup>
-        <exclude domain="root" path="." />
-        <exclude domain="file" path="." />
-        <exclude domain="database" path="." />
-        <exclude domain="sharedpref" path="." />
-        <exclude domain="external" path="."/>
-    </cloud-backup>
-    <device-transfer>
-        <exclude domain="root" path="."/>
-        <exclude domain="file" path="."/>
-        <exclude domain="database" path="."/>
-        <exclude domain="sharedpref" path="."/>
-        <exclude domain="external" path="."/>
-    </device-transfer>
+  <cloud-backup>
+    <exclude domain="root"
+      path="." />
+    <exclude domain="file"
+      path="." />
+    <exclude domain="database"
+      path="." />
+    <exclude domain="sharedpref"
+      path="." />
+    <exclude domain="external"
+      path="." />
+  </cloud-backup>
+  <device-transfer>
+    <exclude domain="root"
+      path="." />
+    <exclude domain="file"
+      path="." />
+    <exclude domain="database"
+      path="." />
+    <exclude domain="sharedpref"
+      path="." />
+    <exclude domain="external"
+      path="." />
+  </device-transfer>
 </data-extraction-rules>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="."/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="."/>
+        <exclude domain="file" path="."/>
+        <exclude domain="database" path="."/>
+        <exclude domain="sharedpref" path="."/>
+        <exclude domain="external" path="."/>
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
### What was the problem?

This PR resolves #1937

### How was it solved?

- [x] Disable backup and d2d data transfer for devices with Android 12 or higher.

Introduced `dataExtractionRules` attribute [is available](https://developer.android.com/about/versions/12/behavior-changes-12#backup-restore) for API 31 (Android 12) and higher. 

We are keeping `allowBackup` and `fullBackupContent` attributes for Android versions before API 31.

### How was it tested?

- [x] Android Emulator.