### PR TITLE
Implement certificate pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log
 
 *.keystore
 *.pem
+*.cer
 pepk.jar
 !debug.keystore
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ Before building on iOS, make sure that Lisk Service's SSL certificate is added t
 2. Go to _Build Phases_/ _Copy Bundle Resources_/ _Add button_.
 3. Add the `server-cert.cer` file.
 
-After this, you can build normally the app.
-
 To build the app on iOS run:
 
 ```bash
@@ -155,8 +153,6 @@ $ npm run build:ios
 
 #### Build on Android
 Before building on Android, make sure that Lisk Service's SSL certificate (`server-cert.cer`) is added to the `android/app/src/main/assets` folder.
-
-After this, you can build normally the app.
 
 To build the app on Android run:
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,50 @@ The process is:
 
 More details can be found [here](https://armen-mkrtchian.medium.com/run-cocoapods-on-apple-silicon-and-macos-big-sur-developer-transition-kit-b62acffc1387).
 
-### Build on iOS
+### Build
+
+Before building the app, make sure to have a valid and non-expired SSL certificate from Lisk Service.
+
+All API calls to Lisk Service pass through a Certificate Pinning process, for which a valid `server-cert.cer` file should be added to the source code before any build. Devnet is excluded from this.
+
+For creating the certificates:
+
+1. Fetch them from Lisk Service server:
+    ```bash
+    openssl s_client -showcerts -servername <LISK SERVICE NETWORK DOMAIN> -connect <LISK SERVICE NETWORK DOMAIN>:443 </dev/null
+    ```
+    `LISK SERVICE NETWORK DOMAIN` could be for example, `betanet-service.lisk.com`.
+2. The previous command will print on the terminal all the certificates available on that server. Copy the root certificate (from `BEGIN` to `END`), create the file `server-cert.pem` on the root folder of the project and paste the certificate content on it.
+
+3. Convert the certificate from `.pem` to `.cer`:
+    ```bash
+    openssl x509 -in server-cert.pem -outform der -out server-cert.cer
+    ```
+
+The certificate location varies based on the platform which the app is being build. See the "Build on iOS" and "Build on Android" sections for details.
+
+More details of the certificate generation can be found on [the docs of the Certificate Pinning library that we use](https://github.com/MaxToyberman/react-native-ssl-pinning).
+#### Build on iOS
+
+Before building on iOS, make sure that Lisk Service's SSL certificate is added to the "_Bundle Resources_" of the app:
+1. Open the app on Xcode.
+2. Go to _Build Phases_/ _Copy Bundle Resources_/ _Add button_.
+3. Add the `server-cert.cer` file.
+
+After this, you can build normally the app.
+
+To build the app on iOS run:
 
 ```bash
 $ npm run build:ios
 ```
 
-### Build on Android
+#### Build on Android
+Before building on Android, make sure that Lisk Service's SSL certificate (`server-cert.cer`) is added to the `android/app/src/main/assets` folder.
+
+After this, you can build normally the app.
+
+To build the app on Android run:
 
 ```bash
 $ npm run build:android

--- a/ios/Lisk.xcodeproj/project.pbxproj
+++ b/ios/Lisk.xcodeproj/project.pbxproj
@@ -58,8 +58,8 @@
 		7E342449C772440C0543475E /* libPods-LiskApp-LiskDev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADEFA1D98EA6EED99C4BE95A /* libPods-LiskApp-LiskDev.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		A23A1AEDA1EFDCFFD8819768 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		CB0756202A863AED00508875 /* server-cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = CB07561F2A863AED00508875 /* server-cert.cer */; };
 		CB9BAE4C26FF857E00EE1F48 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */; };
+		CBD727A22A8A52DA00D33815 /* server-cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBD727A12A8A52DA00D33815 /* server-cert.cer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,10 +168,9 @@
 		AA82A2E09394A9AAB9AE56B8 /* Pods-Lisk-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Lisk-tvOSTests/Pods-Lisk-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ADEFA1D98EA6EED99C4BE95A /* libPods-LiskApp-LiskDev.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LiskApp-LiskDev.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC88364E9EC48DA3B52412DA /* Pods-LiskApp-Lisk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiskApp-Lisk.debug.xcconfig"; path = "Target Support Files/Pods-LiskApp-Lisk/Pods-LiskApp-Lisk.debug.xcconfig"; sourceTree = "<group>"; };
-		CB07561D2A8635DA00508875 /* exp-cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "exp-cert.cer"; path = "../exp-cert.cer"; sourceTree = "<group>"; };
-		CB07561F2A863AED00508875 /* server-cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "server-cert.cer"; path = "../server-cert.cer"; sourceTree = "<group>"; };
 		CB9BAE4A26FF857E00EE1F48 /* Lisk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Lisk-Bridging-Header.h"; sourceTree = "<group>"; };
 		CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
+		CBD727A12A8A52DA00D33815 /* server-cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "server-cert.cer"; path = "../server-cert.cer"; sourceTree = "<group>"; };
 		D1FBD00EBB5BF68B90C6ACFF /* Pods-Lisk-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Lisk-tvOSTests/Pods-Lisk-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		D62835011F787A4FF10BFE9B /* Pods-LiskApp-Lisk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiskApp-Lisk.release.xcconfig"; path = "Target Support Files/Pods-LiskApp-Lisk/Pods-LiskApp-Lisk.release.xcconfig"; sourceTree = "<group>"; };
 		E01BE00324F84FB5D6186030 /* Pods-LiskApp-LiskDev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiskApp-LiskDev.release.xcconfig"; path = "Target Support Files/Pods-LiskApp-LiskDev/Pods-LiskApp-LiskDev.release.xcconfig"; sourceTree = "<group>"; };
@@ -344,8 +343,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
-				CB07561F2A863AED00508875 /* server-cert.cer */,
-				CB07561D2A8635DA00508875 /* exp-cert.cer */,
+				CBD727A12A8A52DA00D33815 /* server-cert.cer */,
 				79DD0C352A3750F500E2DC9D /* LiskQA */,
 				79EFB6BC2A39221F0006FBEF /* MobileProtect.plist */,
 				CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */,
@@ -579,7 +577,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB0756202A863AED00508875 /* server-cert.cer in Resources */,
+				CBD727A22A8A52DA00D33815 /* server-cert.cer in Resources */,
 				7952112E25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf in Resources */,
 				79EFB6BD2A39221F0006FBEF /* MobileProtect.plist in Resources */,
 				7952113A25F7660200CCF7F8 /* icomoon.ttf in Resources */,

--- a/ios/Lisk.xcodeproj/project.pbxproj
+++ b/ios/Lisk.xcodeproj/project.pbxproj
@@ -57,7 +57,8 @@
 		79EFB6BD2A39221F0006FBEF /* MobileProtect.plist in Resources */ = {isa = PBXBuildFile; fileRef = 79EFB6BC2A39221F0006FBEF /* MobileProtect.plist */; };
 		7E342449C772440C0543475E /* libPods-LiskApp-LiskDev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADEFA1D98EA6EED99C4BE95A /* libPods-LiskApp-LiskDev.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		A23A1AEDA1EFDCFFD8819768 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		A23A1AEDA1EFDCFFD8819768 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		CB0756202A863AED00508875 /* server-cert.cer in Resources */ = {isa = PBXBuildFile; fileRef = CB07561F2A863AED00508875 /* server-cert.cer */; };
 		CB9BAE4C26FF857E00EE1F48 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */; };
 /* End PBXBuildFile section */
 
@@ -167,6 +168,8 @@
 		AA82A2E09394A9AAB9AE56B8 /* Pods-Lisk-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Lisk-tvOSTests/Pods-Lisk-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ADEFA1D98EA6EED99C4BE95A /* libPods-LiskApp-LiskDev.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LiskApp-LiskDev.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC88364E9EC48DA3B52412DA /* Pods-LiskApp-Lisk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiskApp-Lisk.debug.xcconfig"; path = "Target Support Files/Pods-LiskApp-Lisk/Pods-LiskApp-Lisk.debug.xcconfig"; sourceTree = "<group>"; };
+		CB07561D2A8635DA00508875 /* exp-cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "exp-cert.cer"; path = "../exp-cert.cer"; sourceTree = "<group>"; };
+		CB07561F2A863AED00508875 /* server-cert.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "server-cert.cer"; path = "../server-cert.cer"; sourceTree = "<group>"; };
 		CB9BAE4A26FF857E00EE1F48 /* Lisk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Lisk-Bridging-Header.h"; sourceTree = "<group>"; };
 		CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
 		D1FBD00EBB5BF68B90C6ACFF /* Pods-Lisk-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lisk-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Lisk-tvOSTests/Pods-Lisk-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -189,7 +192,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A23A1AEDA1EFDCFFD8819768 /* BuildFile in Frameworks */,
+				A23A1AEDA1EFDCFFD8819768 /* (null) in Frameworks */,
 				6113352CBF486318C1753F84 /* libPods-LiskApp-Lisk.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -341,6 +344,8 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				CB07561F2A863AED00508875 /* server-cert.cer */,
+				CB07561D2A8635DA00508875 /* exp-cert.cer */,
 				79DD0C352A3750F500E2DC9D /* LiskQA */,
 				79EFB6BC2A39221F0006FBEF /* MobileProtect.plist */,
 				CB9BAE4B26FF857E00EE1F48 /* Bridge.swift */,
@@ -574,6 +579,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB0756202A863AED00508875 /* server-cert.cer in Resources */,
 				7952112E25F765EA00CCF7F8 /* BasierCircle-SemiBold.otf in Resources */,
 				79EFB6BD2A39221F0006FBEF /* MobileProtect.plist in Resources */,
 				7952113A25F7660200CCF7F8 /* icomoon.ttf in Resources */,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,19 @@
 PODS:
+  - AFNetworking (4.0.1):
+    - AFNetworking/NSURLSession (= 4.0.1)
+    - AFNetworking/Reachability (= 4.0.1)
+    - AFNetworking/Security (= 4.0.1)
+    - AFNetworking/Serialization (= 4.0.1)
+    - AFNetworking/UIKit (= 4.0.1)
+  - AFNetworking/NSURLSession (4.0.1):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (4.0.1)
+  - AFNetworking/Security (4.0.1)
+  - AFNetworking/Serialization (4.0.1)
+  - AFNetworking/UIKit (4.0.1):
+    - AFNetworking/NSURLSession
   - boost (1.76.0)
   - BVLinearGradient (2.7.3):
     - React-Core
@@ -492,6 +507,9 @@ PODS:
     - React
   - RNShare (7.9.1):
     - React-Core
+  - RNSslPinning (1.5.7):
+    - AFNetworking (~> 4.0)
+    - React
   - RNSVG (12.5.1):
     - React-Core
   - RNVectorIcons (8.1.0):
@@ -598,12 +616,14 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNScreenshotPrevent (from `../node_modules/react-native-screenshot-prevent`)
   - RNShare (from `../node_modules/react-native-share`)
+  - RNSslPinning (from `../node_modules/react-native-ssl-pinning`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
+    - AFNetworking
     - CocoaAsyncSocket
     - Flipper
     - Flipper-Boost-iOSX
@@ -759,6 +779,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screenshot-prevent"
   RNShare:
     :path: "../node_modules/react-native-share"
+  RNSslPinning:
+    :path: "../node_modules/react-native-ssl-pinning"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   RNVectorIcons:
@@ -767,6 +789,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: fbe308a1d19a8133f69e033abc85d8008644f5e3
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
@@ -849,6 +872,7 @@ SPEC CHECKSUMS:
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNScreenshotPrevent: 0526b14371b2d0545957070cf30bc0a29a5c4bf5
   RNShare: a5dc3b9c53ddc73e155b8cd9a94c70c91913c43c
+  RNSslPinning: 373fddf38420bec9c591376f3e4a24df1051b39a
   RNSVG: d7d7bc8229af3842c9cfc3a723c815a52cdd1105
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-native-share": "^7.5.0",
     "react-native-snap-carousel": "3.9.1",
     "react-native-splash-screen": "3.2.0",
+    "react-native-ssl-pinning": "^1.5.7",
     "react-native-svg": "^12.5.0",
     "react-native-tcp": "^4.0.0",
     "react-native-udp": "^4.1.5",

--- a/src/modules/Accounts/api/useAccountTokenBalancesQuery.js
+++ b/src/modules/Accounts/api/useAccountTokenBalancesQuery.js
@@ -17,7 +17,7 @@ export function useAccountTokenBalancesQuery(
 ) {
   const config = {
     url: `${API_URL}/token/balances`,
-    method: 'get',
+    method: 'GET',
     event: 'get.token.balances',
     ...customConfig,
     params: {

--- a/src/modules/Accounts/api/useAccountTokensFullDataQuery.js
+++ b/src/modules/Accounts/api/useAccountTokensFullDataQuery.js
@@ -27,7 +27,7 @@ export function useAccountTokensFullDataQuery(
 
   const config = {
     url: `${API_URL}/token/balances`,
-    method: 'get',
+    method: 'GET',
     event: 'get.token.balances',
     ...customConfig,
     params: {

--- a/src/modules/Accounts/api/useAccountTokensQuery.js
+++ b/src/modules/Accounts/api/useAccountTokensQuery.js
@@ -16,7 +16,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useAccountTokensQuery(address, { config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/token/balances`,
-    method: 'get',
+    method: 'GET',
     event: 'get.token.balances',
     ...customConfig,
     params: {

--- a/src/modules/Accounts/api/useAccountTransactionsQuery.js
+++ b/src/modules/Accounts/api/useAccountTransactionsQuery.js
@@ -19,7 +19,7 @@ export function useAccountTransactionsQuery(
 ) {
   const config = {
     url: `${API_URL}/transactions`,
-    method: 'get',
+    method: 'GET',
     event: 'get.transactions',
     ...customConfig,
     params: {

--- a/src/modules/Accounts/api/usePriceTickerQuery.js
+++ b/src/modules/Accounts/api/usePriceTickerQuery.js
@@ -16,7 +16,7 @@ import apiClient from 'utilities/api/APIClient';
 export function usePriceTickerQuery({ config: customConfig = {} } = {}) {
   const config = {
     url: `${API_URL}/market/prices`,
-    method: 'get',
+    method: 'GET',
     event: 'get.prices',
     ...customConfig,
   };

--- a/src/modules/Auth/api/useAuthQuery.js
+++ b/src/modules/Auth/api/useAuthQuery.js
@@ -14,7 +14,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useAuthQuery(address, { config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/auth`,
-    method: 'get',
+    method: 'GET',
     event: 'get.auth',
     ...customConfig,
     params: {

--- a/src/modules/BlockchainApplication/api/useApplicationStatsQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationStatsQuery.js
@@ -7,7 +7,7 @@ import liskAPIClient from 'utilities/api/LiskAPIClient';
 export function useApplicationStatsQuery() {
   const config = {
     url: `${API_URL}/blockchain/apps/statistics`,
-    method: 'get',
+    method: 'GET',
   };
 
   const keys = useQueryKeys([GET_APPLICATION_STATS, config]);

--- a/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationSupportedTokensQuery.js
@@ -14,7 +14,10 @@ import { useTokensMetaQuery } from './useTokensMetaQuery';
 export function useApplicationSupportedTokensQuery(application) {
   const toApplicationApiClient = useRef(new APIClient());
 
-  toApplicationApiClient.current.create(application?.serviceURLs[0]);
+  toApplicationApiClient.current.create({
+    ...application?.serviceURLs[0],
+    enableCertPinning: application?.chainName === 'lisk_mainchain',
+  });
 
   const {
     data: { data: tokensMetaData } = {},

--- a/src/modules/BlockchainApplication/api/useApplicationsMetaQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationsMetaQuery.js
@@ -14,7 +14,7 @@ import liskAPIClient from 'utilities/api/LiskAPIClient';
 export function useApplicationsMetaQuery({ config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/blockchain/apps/meta`,
-    method: 'get',
+    method: 'GET',
     event: 'get.blockchain.apps.meta',
     ...customConfig,
     params: {

--- a/src/modules/BlockchainApplication/api/useApplicationsQuery.js
+++ b/src/modules/BlockchainApplication/api/useApplicationsQuery.js
@@ -6,7 +6,7 @@ import liskAPIClient from 'utilities/api/LiskAPIClient';
 export function getApplicationsQueryConfigCreator() {
   return (customConfig = {}) => ({
     url: `${API_URL}/blockchain/apps`,
-    method: 'get',
+    method: 'GET',
     event: 'get.blockchain.apps',
     ...customConfig,
     params: { limit: LIMIT, ...customConfig.params },

--- a/src/modules/BlockchainApplication/api/useSupportedTokensQuery.js
+++ b/src/modules/BlockchainApplication/api/useSupportedTokensQuery.js
@@ -14,7 +14,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useSupportedTokensQuery({ config: customConfig = {}, options, client } = {}) {
   const config = {
     url: `${API_URL}/token/summary`,
-    method: 'get',
+    method: 'GET',
     event: 'get.token.summary',
     ...customConfig,
     params: customConfig?.params,

--- a/src/modules/BlockchainApplication/api/useTokenMetaQuery.js
+++ b/src/modules/BlockchainApplication/api/useTokenMetaQuery.js
@@ -15,7 +15,7 @@ import liskAPIClient from 'utilities/api/LiskAPIClient';
 export function useTokenMetaQuery(tokenID, { config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/blockchain/apps/meta/tokens`,
-    method: 'get',
+    method: 'GET',
     event: 'get.blockchain.apps.meta.tokens',
     ...customConfig,
     params: {

--- a/src/modules/BlockchainApplication/api/useTokensMetaQuery.js
+++ b/src/modules/BlockchainApplication/api/useTokensMetaQuery.js
@@ -7,7 +7,7 @@ import liskAPIClient from 'utilities/api/LiskAPIClient';
 export function getTokensMetaQueryConfig(customConfig = {}) {
   return {
     url: `${API_URL}/blockchain/apps/meta/tokens`,
-    method: 'get',
+    method: 'GET',
     event: 'get.blockchain.apps.meta.tokens',
     ...customConfig,
     params: { limit: LIMIT, ...customConfig.params },

--- a/src/modules/BlockchainApplication/hooks/useApplicationsLocalStorage.js
+++ b/src/modules/BlockchainApplication/hooks/useApplicationsLocalStorage.js
@@ -25,7 +25,7 @@ export function useApplicationsLocalStorage() {
 
   const queryConfig = {
     url: `${API_URL}/blockchain/apps/meta`,
-    method: 'get',
+    method: 'GET',
     event: 'get.blockchain.apps.meta',
     transformResult: transformApplicationsMetaQueryResult,
     params: {

--- a/src/modules/BlockchainApplication/hooks/useBootstrapCurrentApplication.js
+++ b/src/modules/BlockchainApplication/hooks/useBootstrapCurrentApplication.js
@@ -54,7 +54,10 @@ export function useBootstrapCurrentApplication() {
   // Create Client API with first element of default apps
   useEffect(() => {
     if (defaultApplicationsMetaData?.data[0]?.serviceURLs) {
-      apiClient.create(defaultApplicationsMetaData?.data[0].serviceURLs[0]);
+      apiClient.create({
+        ...defaultApplicationsMetaData?.data[0].serviceURLs[0],
+        enableCertPinning: defaultApplicationsMetaData?.data[0].chainName === 'lisk_mainchain',
+      });
     }
   }, [defaultApplicationsMetaData?.data]);
 

--- a/src/modules/BlockchainApplication/hooks/useCurrentApplication.js
+++ b/src/modules/BlockchainApplication/hooks/useCurrentApplication.js
@@ -40,7 +40,10 @@ export function useCurrentApplication() {
   const { currentApplication } = useApplications();
 
   const handleSetData = (selectedApplication) => {
-    apiClient.create(selectedApplication.serviceURL);
+    apiClient.create({
+      ...selectedApplication.serviceURL,
+      enableCertPinning: selectedApplication.chainName === 'lisk_mainchain',
+    });
 
     currentApplication.setData(selectedApplication);
 

--- a/src/modules/Network/api/useCommandParametersSchemasQuery.js
+++ b/src/modules/Network/api/useCommandParametersSchemasQuery.js
@@ -18,7 +18,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useCommandParametersSchemasQuery({ config: customConfig = {}, options } = {}) {
   const config = {
     url: `${API_URL}/schemas`,
-    method: 'get',
+    method: 'GET',
     event: 'get.schemas',
     ...customConfig,
     params: { ...customConfig.params },

--- a/src/modules/Network/api/useNetworkStatusQuery.js
+++ b/src/modules/Network/api/useNetworkStatusQuery.js
@@ -16,7 +16,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useNetworkStatusQuery({ config: customConfig = {}, options = {}, client } = {}) {
   const config = {
     url: `${API_URL}/network/status`,
-    method: 'get',
+    method: 'GET',
     event: 'get.network.status',
     ...customConfig,
   };

--- a/src/modules/Transactions/api/useBroadcastTransactionMutation.js
+++ b/src/modules/Transactions/api/useBroadcastTransactionMutation.js
@@ -15,7 +15,7 @@ export default function useBroadcastTransactionMutation(options = {}) {
     ({ transaction }) => {
       const config = {
         url: `${API_URL}/transactions`,
-        method: 'post',
+        method: 'POST',
         event: 'post.transactions',
         data: { transaction },
       };

--- a/src/modules/Transactions/api/useDryRunTransactionMutation.js
+++ b/src/modules/Transactions/api/useDryRunTransactionMutation.js
@@ -14,7 +14,7 @@ export default function useDryRunTransactionMutation({ onSuccess, onError, ...op
     ({ transaction }) => {
       const config = {
         url: `${API_URL}/transactions/dryrun`,
-        method: 'post',
+        method: 'POST',
         event: 'post.transactions.dryrun',
         data: { transaction },
       };

--- a/src/modules/Transactions/api/useFeesQuery.js
+++ b/src/modules/Transactions/api/useFeesQuery.js
@@ -12,7 +12,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useFeesQuery({ config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/fees`,
-    method: 'get',
+    method: 'GET',
     event: 'get.fees',
     ...customConfig,
   };

--- a/src/modules/Transactions/api/useTransactionEstimateFeesMutation.js
+++ b/src/modules/Transactions/api/useTransactionEstimateFeesMutation.js
@@ -17,7 +17,7 @@ export default function useTransactionEstimateFeesMutation({
     ({ transaction }) => {
       const config = {
         url: `${API_URL}/transactions/estimate-fees`,
-        method: 'post',
+        method: 'POST',
         event: 'post.transactions.estimate-fees',
         data: { transaction },
       };

--- a/src/modules/Transactions/api/useTransactionPoolQuery.js
+++ b/src/modules/Transactions/api/useTransactionPoolQuery.js
@@ -13,7 +13,7 @@ import { GET_TRANSACTION_POOL_QUERY } from 'utilities/api/queries';
 export function useTransactionPoolQuery({ config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/transactions`,
-    method: 'get',
+    method: 'GET',
     event: 'get.transactions',
     ...customConfig,
     params: {

--- a/src/modules/Transactions/api/useTransactionQuery.js
+++ b/src/modules/Transactions/api/useTransactionQuery.js
@@ -14,7 +14,7 @@ import { API_URL } from 'utilities/api/constants';
 export function useTransactionQuery(id, { config: customConfig = {}, options = {} } = {}) {
   const config = {
     url: `${API_URL}/transactions`,
-    method: 'get',
+    method: 'GET',
     event: 'get.transaction',
     ...customConfig,
     params: {

--- a/src/modules/Transactions/api/useTransactionsQuery.js
+++ b/src/modules/Transactions/api/useTransactionsQuery.js
@@ -6,7 +6,7 @@ import { useQueryKeys } from 'utilities/api/hooks/useQueryKeys';
 export function useTransactionsQueryParams({ config: customConfig = {} } = {}) {
   const config = {
     url: `${API_URL}/transactions`,
-    method: 'get',
+    method: 'GET',
     event: 'get.transactions',
     ...customConfig,
     params: {

--- a/src/utilities/api/APIClient.js
+++ b/src/utilities/api/APIClient.js
@@ -51,7 +51,7 @@ export class APIClient {
       headers: finalHeaders,
     };
 
-    if (this.enableCertPinning) {
+    if (this.enableCertPinning && process.env.NETWORK !== 'devnet') {
       fetchOptions.sslPinning = {
         certs: ['server-cert'],
       };
@@ -65,6 +65,7 @@ export class APIClient {
     }
 
     const response = await fetch(finalUrl, fetchOptions);
+
     const responseData = await response.json();
 
     if (response.status !== 200) {

--- a/src/utilities/api/APIClient.js
+++ b/src/utilities/api/APIClient.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { io } from 'socket.io-client';
+import { fetch } from 'react-native-ssl-pinning';
 
 import { METHOD } from './constants';
 
@@ -7,6 +8,8 @@ export class APIClient {
   http = null;
 
   ws = null;
+
+  certs = null;
 
   axiosConfig = {
     timeout: 10000,
@@ -30,11 +33,26 @@ export class APIClient {
   }
 
   rest(config) {
+    if (this.certs) {
+      return fetch(this.http, {
+        ...this.axiosConfig,
+        ...config,
+        sslPinning: {
+          certs: this.certs,
+        },
+      });
+    }
     return this.http?.request({ ...this.http.defaults, ...config });
   }
 
-  create({ http, ws } = {}) {
+  create({ http, ws, apiCertificatePublicKey } = {}) {
+    console.log({ apiCertificatePublicKey });
+
     this.ws = io(`${ws}/blockchain`);
+
+    if (apiCertificatePublicKey) {
+      // TODO: Import certificate and assign to this.certs
+    }
 
     const request = axios.create({
       ...this.axiosConfig,

--- a/src/utilities/api/APIClient.js
+++ b/src/utilities/api/APIClient.js
@@ -49,12 +49,11 @@ export class APIClient {
       ...otherConfig,
       method: method || 'GET',
       headers: finalHeaders,
-      pkPinning: true,
     };
 
     if (this.enableCertPinning) {
       fetchOptions.sslPinning = {
-        certs: ['exp-cert'],
+        certs: ['server-cert'],
       };
     } else {
       fetchOptions.disableAllSecurity = true;

--- a/src/utilities/api/LiskAPIClient.js
+++ b/src/utilities/api/LiskAPIClient.js
@@ -6,6 +6,7 @@ const liskAPIClient = new APIClient();
 liskAPIClient.create({
   http: API_BASE_URL,
   ws: WS_BASE_URL,
+  enableCertPinning: true,
 });
 
 export default liskAPIClient;

--- a/src/utilities/api/hooks/useCustomInfiniteQuery.test.js
+++ b/src/utilities/api/hooks/useCustomInfiniteQuery.test.js
@@ -11,7 +11,7 @@ describe('useCustomInfiniteQuery hook', () => {
   const config = {
     baseURL: API_BASE_URL,
     url: `${API_URL}/mock/custom-infinite-query`,
-    method: 'get',
+    method: 'GET',
     params: {
       limit: LIMIT,
     },

--- a/src/utilities/api/hooks/useCustomQuery.test.js
+++ b/src/utilities/api/hooks/useCustomQuery.test.js
@@ -11,7 +11,7 @@ describe('useCustomQuery hook', () => {
   const config = {
     baseURL: API_BASE_URL,
     url: `${API_URL}/mock/custom-query`,
-    method: 'get',
+    method: 'GET',
     params: {
       limit: LIMIT,
     },

--- a/src/utilities/api/hooks/useInvokeQuery.js
+++ b/src/utilities/api/hooks/useInvokeQuery.js
@@ -10,7 +10,7 @@ import { useCustomQuery } from './useCustomQuery';
 export function useInvokeQuery({ config: customConfig = {}, options }) {
   const config = {
     url: `/api/${API_VERSION}/invoke`,
-    method: 'post',
+    method: 'POST',
     event: 'post.invoke',
     ...customConfig,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10362,6 +10362,11 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
 
+q@^1.4.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
+
 qrcode@^1.4.4:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.3.tgz#03afa80912c0dccf12bc93f615a535aad1066170"
@@ -10769,6 +10774,13 @@ react-native-splash-screen@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
+
+react-native-ssl-pinning@^1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/react-native-ssl-pinning/-/react-native-ssl-pinning-1.5.7.tgz#2d9af23ca9b41adeae3ee4cd14751df41da2cbea"
+  integrity sha512-lDdd9uXTPfglUGew4hASaqsWYbPDl0mJ16EU7CLRM0hfdam/lQhVJsv/fIWgz0/8ydHMMy73HbooSPsFZNHVPw==
+  dependencies:
+    q "^1.4.1"
 
 react-native-svg@^12.5.0:
   version "12.5.1"


### PR DESCRIPTION
### What was the problem?

This PR resolves #1897

### How was it solved?

- [x] Implement SSL pinning using OkHttp 3 in Android, and AFNetworking on iOS (implementation through [react-native-ssl-pinning](https://github.com/MaxToyberman/react-native-ssl-pinning)).
- [x] Refactor our `APIClient` class to use the `fetch` function from `react-native-ssl-pinning` instead of `axios`.
- [x] Only apply SSL pinning validation for Lisk Mainchain applications. All other sidechains used as current application by the user are not being verified.
- [x] Update our `README.md` with the instructions of how to add the certificates for build and distribution.

### How was it tested?

- [x] iOS Simulator:

First tried with an expired certificate. Then, removed the expired certificate, added the valid one that we will be using for betanet [(cross-signed certificate from Let's Encrypt "ISRG Root X1")](https://crt.sh/?id=3958242236) and bundled the app again:

https://github.com/LiskHQ/lisk-mobile/assets/9727036/d09e7f9f-1660-45d3-ac38-d74466e8581b

- [x] Android Emulator:

Since Android picks up the certificate programatically from `android/app/src/main/assets`, we can easily test by changing the `certs` field of `fetchOptions.sslPinning` on the method `APIClient.rest` from an invalid, to a valid certificate supported by betanet:

https://github.com/LiskHQ/lisk-mobile/assets/9727036/abdc6ea1-dc78-4c18-86c9-cee100ebdf0a