### PR TITLE
Fix applications stats chart crashing

### DIFF
--- a/src/modules/BlockchainApplication/components/ApplicationsStats/ApplicationsStats.js
+++ b/src/modules/BlockchainApplication/components/ApplicationsStats/ApplicationsStats.js
@@ -43,7 +43,7 @@ export default function ApplicationsStats(props) {
         isLoading={isLoadingStatsData}
         error={errorOnStatsData}
         renderData={(data) => {
-          const series = [data.registered, data.active, data.terminated];
+          const series = [data.registered, data.activated, data.terminated];
 
           const showPieChart = series.reduce((acc, seriesItem) => acc || !!seriesItem, false);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #2104

### How was it solved?

- [x] Update app stats series key of "activated" to prevent crash on pie rendering.

### How was it tested?

- [x] iOS simulator.
![Simulator Screenshot - iPhone 14 Pro Max - 2023-10-26 at 14 05 16](https://github.com/LiskHQ/lisk-mobile/assets/9727036/b1ac04bd-8443-4906-a292-635bf492b2a6)
