### PR TITLE
Fix end to end test for send token screen

### DIFF
--- a/e2e/packages/SendToken.e2e.js
+++ b/e2e/packages/SendToken.e2e.js
@@ -1,9 +1,9 @@
 /* eslint-disable max-statements */
-import { device, element, by } from 'detox';
+import { device, element, by, waitFor } from 'detox';
 import testConstants from '../utils/testConstants';
 import { signInUser } from '../commands/auth';
 
-describe.skip('Send Token Screen', () => {
+describe('Send Token Screen', () => {
   beforeAll(async () => {
     await device.launchApp();
     await element(by.id('intro-screen')).swipe('left');
@@ -19,40 +19,59 @@ describe.skip('Send Token Screen', () => {
   });
 
   it('should calculate initialization fee for new addresses', async () => {
-    await element(by.id('recipient-address')).replaceText(testConstants.newAddress);
-    await element(by.id('next-step-button')).tap();
-    await element(by.id('token-amount')).typeText('0.01');
+    await element(by.id('recipient-address')).typeText(`${testConstants.newAddress}`);
+    await element(by.id('send-token-screen')).tap();
+    await element(by.id('token-amount')).typeText('0.01\n');
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('fees-breakdown-toggle')).tap();
-    await expect(element(by.id('select-token-step-screen'))).toBeVisible();
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
     await expect(element(by.id('initialization-fee'))).toBeVisible();
   });
 
   it('should not add initialization fee for old addresses', async () => {
     device.reloadReactNative();
-    await element(by.id('account-list-item')).atIndex(0).tap();
+    await element(by.id('account-list-item')).tap();
     await element(by.id('send-tokens-button')).tap();
-    await element(by.id('recipient-address')).replaceText(testConstants.address);
-    await element(by.id('next-step-button')).tap();
+    await element(by.id('recipient-address')).typeText(`${testConstants.address}`);
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('token-amount')).typeText('0.01');
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('fees-breakdown-toggle')).tap();
-    await expect(element(by.id('select-token-step-screen'))).toBeVisible();
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
     await expect(element(by.id('initialization-fee'))).not.toBeVisible();
+    await element(by.id('next-step-button')).tap();
   });
 
   it('should show transaction summary screen', async () => {
+    device.reloadReactNative();
+    await element(by.id('account-list-item')).tap();
+    await element(by.id('send-tokens-button')).tap();
+    await element(by.id('recipient-address')).typeText(`${testConstants.address}`);
+    await element(by.id('send-token-screen')).tap();
+    await element(by.id('token-amount')).typeText('0.01\n');
+    await element(by.id('send-token-screen')).tap();
+    await element(by.id('fees-breakdown-toggle')).tap();
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
+    await expect(element(by.id('initialization-fee'))).not.toBeVisible();
     await element(by.id('next-step-button')).tap();
     await expect(element(by.id('transaction-summary-screen'))).toBeVisible();
   });
 
   it('should successfully send a transaction', async () => {
     device.reloadReactNative();
-    await element(by.id('account-list-item')).atIndex(0).tap();
+    await element(by.id('account-list-item')).tap();
     await element(by.id('send-tokens-button')).tap();
-    await element(by.id('recipient-address')).replaceText(testConstants.address);
-    await element(by.id('next-step-button')).tap();
-    await element(by.id('token-amount')).typeText('0.01');
+    await element(by.id('recipient-address')).typeText(`${testConstants.address}`);
+    await element(by.id('send-token-screen')).tap();
+    await element(by.id('token-amount')).typeText('0.01\n');
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('fees-breakdown-toggle')).tap();
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
+    await expect(element(by.id('initialization-fee'))).not.toBeVisible();
     await element(by.id('next-step-button')).tap();
+    await waitFor(element(by.id('send-transaction-button')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('send-transaction-button')).tap();
     await expect(element(by.id('transaction-confirmation-screen'))).toBeVisible();
     await element(by.id('decrypt-password-input')).typeText(testConstants.password);
@@ -60,14 +79,19 @@ describe.skip('Send Token Screen', () => {
     await expect(element(by.id('sign-transaction-success'))).toBeVisible();
   });
 
-  it('should successfully send a transaction with 0 amount', async () => {
+  it('should successfully send a transaction with 0 amount when amount input is left unchanged', async () => {
     device.reloadReactNative();
-    await element(by.id('account-list-item')).atIndex(0).tap();
+    await element(by.id('account-list-item')).tap();
     await element(by.id('send-tokens-button')).tap();
-    await element(by.id('recipient-address')).replaceText(testConstants.address);
-    await element(by.id('next-step-button')).tap();
+    await element(by.id('recipient-address')).typeText(`${testConstants.address}`);
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('fees-breakdown-toggle')).tap();
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
+    await expect(element(by.id('initialization-fee'))).not.toBeVisible();
     await element(by.id('next-step-button')).tap();
+    await waitFor(element(by.id('send-transaction-button')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('send-transaction-button')).tap();
     await expect(element(by.id('transaction-confirmation-screen'))).toBeVisible();
     await element(by.id('decrypt-password-input')).typeText(testConstants.password);
@@ -75,19 +99,26 @@ describe.skip('Send Token Screen', () => {
     await expect(element(by.id('sign-transaction-success'))).toBeVisible();
   });
 
-  it('should successfully send a cross-chain transaction', async () => {
+  // TODO: Fix cross-chain test
+  it.skip('should successfully send a cross-chain transaction', async () => {
     device.reloadReactNative();
-    await element(by.id('account-list-item')).atIndex(0).tap();
+    await element(by.id('account-list-item')).tap();
     await element(by.id('send-tokens-button')).tap();
-    await element(by.id('recipient-address')).replaceText(testConstants.address);
+    await element(by.id('recipient-address')).typeText(`${testConstants.address}`);
+
+    await element(by.id('send-token-screen')).tap();
     await element(by.id('to-application-select')).tap();
+
     await element(by.id('application-list-Enevti')).tap();
-    await element(by.id('next-step-button')).tap();
     await element(by.id('select-token-picker')).tap();
     await element(by.id('token-select-LSK')).tap();
-    await element(by.id('token-amount')).typeText('0.01');
-    await element(by.id('fees-breakdown-toggle')).tap();
+
+    await element(by.id('send-token-screen')).atIndex(0).swipe('up');
     await element(by.id('next-step-button')).tap();
+
+    await waitFor(element(by.id('send-transaction-button')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('send-transaction-button')).tap();
     await expect(element(by.id('transaction-confirmation-screen'))).toBeVisible();
     await element(by.id('decrypt-password-input')).typeText(testConstants.password);

--- a/e2e/utils/testConstants.js
+++ b/e2e/utils/testConstants.js
@@ -4,7 +4,7 @@ export default {
   sideChainRecoveryPhrase:
     'where glow borrow found path hero produce gasp entry street recycle rich prepare carry almost parrot maze circle nuclear smile unveil captain assist together',
   address: 'lskv6v53emsaen6cwbbk226wusdpa6ojdonunka4x',
-  newAddress: 'lskqzpfr3uq8bm2jee5dkv4ns79uuswjzc9bbpezu',
+  newAddress: 'lskujedwe2nxoeehxwpztuateojsjfv6oge2ktefe',
   emptyAccount: '',
   password: 'Password1!',
   accountName: 'lisker',

--- a/env.test.json
+++ b/env.test.json
@@ -1,6 +1,6 @@
 {
   "RECOVERY_PHRASE": "",
-  "NETWORK": "devnet",
+  "NETWORK": "testnet",
   "SERVICE_API_BASE_URL": "https://testnet-service.lisk.com",
   "SERVICE_WS_BASE_URL": "wss://testnet-service.lisk.com",
   "SERVICE_API_VERSION": "v3",


### PR DESCRIPTION
### What was the problem?

This PR resolves #2017

### How was it solved?

https://github.com/LiskHQ/lisk-mobile/assets/28750984/c8733a6a-f6bd-4557-9f05-b1c2cd06bd24

### How was it tested?
Wrote and fixed tests for: 
- should navigate to send token screen
- should calculate initialization fee for new addresses
- should not add initialization fee for old addresses
- should show transaction summary screen
- should successfully send a transaction
- should successfully send a transaction with 0 amount when amount input is left unchanged
