### PR TITLE
Fix use different storage key for applications on different environments

### DIFF
--- a/src/modules/BlockchainApplication/constants.js
+++ b/src/modules/BlockchainApplication/constants.js
@@ -1,4 +1,6 @@
-export const APPLICATIONS_STORAGE_KEY = '@blockchainApplications';
+import { NETWORK } from 'utilities/api/constants';
+
+export const APPLICATIONS_STORAGE_KEY = `@blockchainApplications-${NETWORK}`;
 
 export const PINNED_APPLICATIONS_STORAGE_KEY = '@blockchainPinnedApplications';
 

--- a/src/modules/BlockchainApplication/constants.js
+++ b/src/modules/BlockchainApplication/constants.js
@@ -1,11 +1,6 @@
 import { NETWORK } from 'utilities/api/constants';
 
-const BASE_APPLICATIONS_STORAGE_KEY = '@blockchainApplications';
-
-export const APPLICATIONS_STORAGE_KEY =
-  NETWORK === 'mainnet'
-    ? BASE_APPLICATIONS_STORAGE_KEY
-    : `${BASE_APPLICATIONS_STORAGE_KEY}-${NETWORK}`;
+export const APPLICATIONS_STORAGE_KEY = `@blockchainApplications-${NETWORK}`;
 
 export const PINNED_APPLICATIONS_STORAGE_KEY = '@blockchainPinnedApplications';
 

--- a/src/modules/BlockchainApplication/constants.js
+++ b/src/modules/BlockchainApplication/constants.js
@@ -1,6 +1,11 @@
 import { NETWORK } from 'utilities/api/constants';
 
-export const APPLICATIONS_STORAGE_KEY = `@blockchainApplications-${NETWORK}`;
+const BASE_APPLICATIONS_STORAGE_KEY = '@blockchainApplications';
+
+export const APPLICATIONS_STORAGE_KEY =
+  NETWORK === 'mainnet'
+    ? BASE_APPLICATIONS_STORAGE_KEY
+    : `${BASE_APPLICATIONS_STORAGE_KEY}-${NETWORK}`;
 
 export const PINNED_APPLICATIONS_STORAGE_KEY = '@blockchainPinnedApplications';
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #2162

### How was it solved?

- [x] Add network env var to applications storage key constant.

### How was it tested?

- [x] iOS simulator.


https://github.com/LiskHQ/lisk-mobile/assets/9727036/fc86c65d-2403-4580-9686-9c6086073de8



