### PR TITLE
docs: Improve Clarity in "Our Pledge" Section Update CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
### What was the problem?
  
Hi Lisk team,  

I noticed a small but important typo in the "Our Pledge" section of the Code of Conduct. The phrase currently says, *"pledge to making participation"*, which is slightly awkward in English. I've updated it to *"pledge to make participation"*, ensuring grammatical accuracy and better readability.  

Thanks for maintaining such an excellent project 😊  
